### PR TITLE
Add latest publications to the XplaiNLP website

### DIFF
--- a/content/publication/android-permission-manager-visual-cues-and-their-effect-on-p/index.md
+++ b/content/publication/android-permission-manager-visual-cues-and-their-effect-on-p/index.md
@@ -1,0 +1,60 @@
+---
+title: 'Android Permission Manager, Visual Cues, and their Effect on Privacy Awareness and Privacy Literacy'
+subtitle: 'Vera Schmitt, Maija Poikela, Sebastian Möller - ARES 2022'
+# Authors
+# If you created a profile for a user (e.g. the default `admin` user), write the username (folder name) here
+# and it will be replaced with their full name and linked to their profile.
+authors:
+- Vera Schmitt
+- Maija Poikela
+- Sebastian Möller
+# Author notes (optional)
+author_notes:
+date: '2022-01-01T00:00:00Z'
+doi: ''
+# Schedule page publish date (NOT publication's date).
+publishDate: '2022-01-01T00:00:00Z'
+# Publication type.
+# Accepts a single type but formatted as a YAML list (for Hugo requirements).
+# Enter a publication type from the CSL standard.
+publication_types: ['paper-conference']
+# Publication name and optional abbreviated publication name.
+publication: 'ARES'
+publication_short:
+abstract: 
+# Summary. An optional shortened abstract.
+summary:
+tags: []
+# Display this page in the Featured widget?
+featured: false
+# Custom links (uncomment lines below)
+# links:
+# - name: Custom Link
+#   url: http://example.org
+url_pdf: 'https://doi.org/10.1145/3538969.3543790'
+url_code: ''
+url_dataset: ''
+url_poster: ''
+url_project: ''
+url_slides: ''
+url_source: ''
+url_video: ''
+# Featured image
+# To use, add an image named `featured.jpg/png` to your page's folder.
+image:
+  caption: ''
+  focal_point: ''
+  preview_only: false
+# Associated Projects (optional).
+#   Associate this publication with one or more of your projects.
+#   Simply enter your project's folder or file name without extension.
+#   E.g. `internal-project` references `content/project/internal-project/index.md`.
+#   Otherwise, set `projects: []`.
+projects: []
+# Slides (optional).
+#   Associate this publication with Markdown slides.
+#   Simply enter your slide deck's filename without extension.
+#   E.g. `slides: "example"` references `content/slides/example/index.md`.
+#   Otherwise, set `slides: ""`.
+slides: ""
+---

--- a/content/publication/dfkinit2b-at-checkthat-2025-leveraging-llms-and-ensemble-of/index.md
+++ b/content/publication/dfkinit2b-at-checkthat-2025-leveraging-llms-and-ensemble-of/index.md
@@ -1,0 +1,66 @@
+---
+title: 'dfkinit2b at CheckThat! 2025: Leveraging LLMs and Ensemble of Methods for Multilingual Claim Normalization'
+subtitle: 'Tatiana Anikina, Ivan Vykopal, Sebastian Kula, Ravi Kiran Chikkala, Natalia Skachkova, Jing Yang, Veronika Solopova, Vera Schmitt, Simon Ostermann - CLEF (Working Notes) 2025'
+# Authors
+# If you created a profile for a user (e.g. the default `admin` user), write the username (folder name) here
+# and it will be replaced with their full name and linked to their profile.
+authors:
+- Tatiana Anikina
+- Ivan Vykopal
+- Sebastian Kula
+- Ravi Kiran Chikkala
+- Natalia Skachkova
+- Jing Yang
+- Veronika Solopova
+- Vera Schmitt
+- Simon Ostermann
+# Author notes (optional)
+author_notes:
+date: '2025-01-01T00:00:00Z'
+doi: ''
+# Schedule page publish date (NOT publication's date).
+publishDate: '2025-01-01T00:00:00Z'
+# Publication type.
+# Accepts a single type but formatted as a YAML list (for Hugo requirements).
+# Enter a publication type from the CSL standard.
+publication_types: ['paper-conference']
+# Publication name and optional abbreviated publication name.
+publication: 'CLEF (Working Notes)'
+publication_short:
+abstract: 
+# Summary. An optional shortened abstract.
+summary:
+tags: []
+# Display this page in the Featured widget?
+featured: false
+# Custom links (uncomment lines below)
+# links:
+# - name: Custom Link
+#   url: http://example.org
+url_pdf: 'https://ceur-ws.org/Vol-4038/paper_62.pdf'
+url_code: ''
+url_dataset: ''
+url_poster: ''
+url_project: ''
+url_slides: ''
+url_source: ''
+url_video: ''
+# Featured image
+# To use, add an image named `featured.jpg/png` to your page's folder.
+image:
+  caption: ''
+  focal_point: ''
+  preview_only: false
+# Associated Projects (optional).
+#   Associate this publication with one or more of your projects.
+#   Simply enter your project's folder or file name without extension.
+#   E.g. `internal-project` references `content/project/internal-project/index.md`.
+#   Otherwise, set `projects: []`.
+projects: []
+# Slides (optional).
+#   Associate this publication with Markdown slides.
+#   Simply enter your slide deck's filename without extension.
+#   E.g. `slides: "example"` references `content/slides/example/index.md`.
+#   Otherwise, set `slides: ""`.
+slides: ""
+---

--- a/content/publication/dissecting-speech-quality-investigating-the-interplay-betwee/index.md
+++ b/content/publication/dissecting-speech-quality-investigating-the-interplay-betwee/index.md
@@ -1,0 +1,61 @@
+---
+title: 'Dissecting Speech Quality: Investigating the Interplay between Overall Quality and Dimensional Perceptions'
+subtitle: 'W Wardah, R Spang, V Schmitt, S Möller - Proceedings of the DEGA Annual Conference on Acoustics. DEGA-Akustik … 2024'
+# Authors
+# If you created a profile for a user (e.g. the default `admin` user), write the username (folder name) here
+# and it will be replaced with their full name and linked to their profile.
+authors:
+- W Wardah
+- R Spang
+- V Schmitt
+- S Möller
+# Author notes (optional)
+author_notes:
+date: '2024-01-01T00:00:00Z'
+doi: ''
+# Schedule page publish date (NOT publication's date).
+publishDate: '2024-01-01T00:00:00Z'
+# Publication type.
+# Accepts a single type but formatted as a YAML list (for Hugo requirements).
+# Enter a publication type from the CSL standard.
+publication_types: ['manuscript']
+# Publication name and optional abbreviated publication name.
+publication: 'Proceedings of the DEGA Annual Conference on Acoustics. DEGA-Akustik …'
+publication_short:
+abstract: 
+# Summary. An optional shortened abstract.
+summary:
+tags: []
+# Display this page in the Featured widget?
+featured: false
+# Custom links (uncomment lines below)
+# links:
+# - name: Custom Link
+#   url: http://example.org
+url_pdf: ''
+url_code: ''
+url_dataset: ''
+url_poster: ''
+url_project: ''
+url_slides: ''
+url_source: ''
+url_video: ''
+# Featured image
+# To use, add an image named `featured.jpg/png` to your page's folder.
+image:
+  caption: ''
+  focal_point: ''
+  preview_only: false
+# Associated Projects (optional).
+#   Associate this publication with one or more of your projects.
+#   Simply enter your project's folder or file name without extension.
+#   E.g. `internal-project` references `content/project/internal-project/index.md`.
+#   Otherwise, set `projects: []`.
+projects: []
+# Slides (optional).
+#   Associate this publication with Markdown slides.
+#   Simply enter your slide deck's filename without extension.
+#   E.g. `slides: "example"` references `content/slides/example/index.md`.
+#   Otherwise, set `slides: ""`.
+slides: ""
+---

--- a/content/publication/ethical-and-legal-limits-of-aligning-large-language-models-t/index.md
+++ b/content/publication/ethical-and-legal-limits-of-aligning-large-language-models-t/index.md
@@ -1,0 +1,60 @@
+---
+title: 'Ethical and Legal Limits of Aligning Large Language Models: The Illusion of Control'
+subtitle: 'V Schmitt, S Ostermann, V Solopova - IntechOpen 2026'
+# Authors
+# If you created a profile for a user (e.g. the default `admin` user), write the username (folder name) here
+# and it will be replaced with their full name and linked to their profile.
+authors:
+- V Schmitt
+- S Ostermann
+- V Solopova
+# Author notes (optional)
+author_notes:
+date: '2026-01-01T00:00:00Z'
+doi: ''
+# Schedule page publish date (NOT publication's date).
+publishDate: '2026-01-01T00:00:00Z'
+# Publication type.
+# Accepts a single type but formatted as a YAML list (for Hugo requirements).
+# Enter a publication type from the CSL standard.
+publication_types: ['manuscript']
+# Publication name and optional abbreviated publication name.
+publication: 'IntechOpen'
+publication_short:
+abstract: 
+# Summary. An optional shortened abstract.
+summary:
+tags: []
+# Display this page in the Featured widget?
+featured: false
+# Custom links (uncomment lines below)
+# links:
+# - name: Custom Link
+#   url: http://example.org
+url_pdf: ''
+url_code: ''
+url_dataset: ''
+url_poster: ''
+url_project: ''
+url_slides: ''
+url_source: ''
+url_video: ''
+# Featured image
+# To use, add an image named `featured.jpg/png` to your page's folder.
+image:
+  caption: ''
+  focal_point: ''
+  preview_only: false
+# Associated Projects (optional).
+#   Associate this publication with one or more of your projects.
+#   Simply enter your project's folder or file name without extension.
+#   E.g. `internal-project` references `content/project/internal-project/index.md`.
+#   Otherwise, set `projects: []`.
+projects: []
+# Slides (optional).
+#   Associate this publication with Markdown slides.
+#   Simply enter your slide deck's filename without extension.
+#   E.g. `slides: "example"` references `content/slides/example/index.md`.
+#   Otherwise, set `slides: ""`.
+slides: ""
+---

--- a/content/publication/fine-tuning-with-hierarchical-prompting-for-robust-propagand/index.md
+++ b/content/publication/fine-tuning-with-hierarchical-prompting-for-robust-propagand/index.md
@@ -1,0 +1,66 @@
+---
+title: 'Fine-tuning with Hierarchical Prompting for Robust Propaganda Classification Across Annotation Schemas'
+subtitle: 'Lukas Stähelin, Veronika Solopova, Max Upravitelev, David Kaplan, Premtim Sahitaj, Ariana Sahitaj, Charlott Jakob, Sebastian Möller, Vera Schmitt - ACL (Findings) 2026'
+# Authors
+# If you created a profile for a user (e.g. the default `admin` user), write the username (folder name) here
+# and it will be replaced with their full name and linked to their profile.
+authors:
+- Lukas Stähelin
+- Veronika Solopova
+- Max Upravitelev
+- David Kaplan
+- Premtim Sahitaj
+- Ariana Sahitaj
+- Charlott Jakob
+- Sebastian Möller
+- Vera Schmitt
+# Author notes (optional)
+author_notes:
+date: '2026-01-01T00:00:00Z'
+doi: ''
+# Schedule page publish date (NOT publication's date).
+publishDate: '2026-01-01T00:00:00Z'
+# Publication type.
+# Accepts a single type but formatted as a YAML list (for Hugo requirements).
+# Enter a publication type from the CSL standard.
+publication_types: ['paper-conference']
+# Publication name and optional abbreviated publication name.
+publication: 'ACL (Findings)'
+publication_short:
+abstract: 
+# Summary. An optional shortened abstract.
+summary:
+tags: []
+# Display this page in the Featured widget?
+featured: false
+# Custom links (uncomment lines below)
+# links:
+# - name: Custom Link
+#   url: http://example.org
+url_pdf: 'https://aclanthology.org/2026.findings-acl.139/'
+url_code: ''
+url_dataset: ''
+url_poster: ''
+url_project: ''
+url_slides: ''
+url_source: ''
+url_video: ''
+# Featured image
+# To use, add an image named `featured.jpg/png` to your page's folder.
+image:
+  caption: ''
+  focal_point: ''
+  preview_only: false
+# Associated Projects (optional).
+#   Associate this publication with one or more of your projects.
+#   Simply enter your project's folder or file name without extension.
+#   E.g. `internal-project` references `content/project/internal-project/index.md`.
+#   Otherwise, set `projects: []`.
+projects: []
+# Slides (optional).
+#   Associate this publication with Markdown slides.
+#   Simply enter your slide deck's filename without extension.
+#   E.g. `slides: "example"` references `content/slides/example/index.md`.
+#   Otherwise, set `slides: ""`.
+slides: ""
+---

--- a/content/publication/from-articles-to-premises-building-primefacts-an-extraction/index.md
+++ b/content/publication/from-articles-to-premises-building-primefacts-an-extraction/index.md
@@ -1,0 +1,67 @@
+---
+title: 'From Articles to Premises: Building PrimeFacts, an Extraction Methodology and Resource for Fact-Checking Evidence'
+subtitle: 'Premtim Sahitaj, Jawan Kolanowski, Ariana Sahitaj, Veronika Solopova, Max Upravitelev, Daniel Röder, Iffat Maab, Junichi Yamagishi, Sebastian Möller, Vera Schmitt - CoRR 2026'
+# Authors
+# If you created a profile for a user (e.g. the default `admin` user), write the username (folder name) here
+# and it will be replaced with their full name and linked to their profile.
+authors:
+- Premtim Sahitaj
+- Jawan Kolanowski
+- Ariana Sahitaj
+- Veronika Solopova
+- Max Upravitelev
+- Daniel Röder
+- Iffat Maab
+- Junichi Yamagishi
+- Sebastian Möller
+- Vera Schmitt
+# Author notes (optional)
+author_notes:
+date: '2026-01-01T00:00:00Z'
+doi: ''
+# Schedule page publish date (NOT publication's date).
+publishDate: '2026-01-01T00:00:00Z'
+# Publication type.
+# Accepts a single type but formatted as a YAML list (for Hugo requirements).
+# Enter a publication type from the CSL standard.
+publication_types: ['article-journal']
+# Publication name and optional abbreviated publication name.
+publication: 'CoRR'
+publication_short:
+abstract: 
+# Summary. An optional shortened abstract.
+summary:
+tags: []
+# Display this page in the Featured widget?
+featured: false
+# Custom links (uncomment lines below)
+# links:
+# - name: Custom Link
+#   url: http://example.org
+url_pdf: 'https://doi.org/10.48550/arXiv.2605.06006'
+url_code: ''
+url_dataset: ''
+url_poster: ''
+url_project: ''
+url_slides: ''
+url_source: ''
+url_video: ''
+# Featured image
+# To use, add an image named `featured.jpg/png` to your page's folder.
+image:
+  caption: ''
+  focal_point: ''
+  preview_only: false
+# Associated Projects (optional).
+#   Associate this publication with one or more of your projects.
+#   Simply enter your project's folder or file name without extension.
+#   E.g. `internal-project` references `content/project/internal-project/index.md`.
+#   Otherwise, set `projects: []`.
+projects: []
+# Slides (optional).
+#   Associate this publication with Markdown slides.
+#   Simply enter your slide deck's filename without extension.
+#   E.g. `slides: "example"` references `content/slides/example/index.md`.
+#   Otherwise, set `slides: ""`.
+slides: ""
+---

--- a/content/publication/graph-based-detection-of-disinformation-narrative-diffusion/index.md
+++ b/content/publication/graph-based-detection-of-disinformation-narrative-diffusion/index.md
@@ -1,0 +1,61 @@
+---
+title: 'Graph-Based Detection of Disinformation Narrative Diffusion between Russian and Ukrainian Telegram Channels'
+subtitle: 'Y Vistak, V Makovska, V Schmitt, V Solopova - Proceedings of the Fifth Ukrainian Natural Language Processing Conference … 2026'
+# Authors
+# If you created a profile for a user (e.g. the default `admin` user), write the username (folder name) here
+# and it will be replaced with their full name and linked to their profile.
+authors:
+- Y Vistak
+- V Makovska
+- V Schmitt
+- V Solopova
+# Author notes (optional)
+author_notes:
+date: '2026-01-01T00:00:00Z'
+doi: ''
+# Schedule page publish date (NOT publication's date).
+publishDate: '2026-01-01T00:00:00Z'
+# Publication type.
+# Accepts a single type but formatted as a YAML list (for Hugo requirements).
+# Enter a publication type from the CSL standard.
+publication_types: ['manuscript']
+# Publication name and optional abbreviated publication name.
+publication: 'Proceedings of the Fifth Ukrainian Natural Language Processing Conference …'
+publication_short:
+abstract: 
+# Summary. An optional shortened abstract.
+summary:
+tags: []
+# Display this page in the Featured widget?
+featured: false
+# Custom links (uncomment lines below)
+# links:
+# - name: Custom Link
+#   url: http://example.org
+url_pdf: ''
+url_code: ''
+url_dataset: ''
+url_poster: ''
+url_project: ''
+url_slides: ''
+url_source: ''
+url_video: ''
+# Featured image
+# To use, add an image named `featured.jpg/png` to your page's folder.
+image:
+  caption: ''
+  focal_point: ''
+  preview_only: false
+# Associated Projects (optional).
+#   Associate this publication with one or more of your projects.
+#   Simply enter your project's folder or file name without extension.
+#   E.g. `internal-project` references `content/project/internal-project/index.md`.
+#   Otherwise, set `projects: []`.
+projects: []
+# Slides (optional).
+#   Associate this publication with Markdown slides.
+#   Simply enter your slide deck's filename without extension.
+#   E.g. `slides: "example"` references `content/slides/example/index.md`.
+#   Otherwise, set `slides: ""`.
+slides: ""
+---

--- a/content/publication/hermeneutichools-at-semeval-2026-task-4-multiperspectivity-a/index.md
+++ b/content/publication/hermeneutichools-at-semeval-2026-task-4-multiperspectivity-a/index.md
@@ -1,0 +1,64 @@
+---
+title: 'hermeneutichools at SemEval-2026 Task 4: Multiperspectivity as a Resource for Narrative Similarity Prediction'
+subtitle: 'M Upravitelev, V Solopova, J Yang, C Jakob, P Sahitaj, A Sahitaj, ... - Proceedings of the 20th International Workshop on Semantic Evaluation (2026 … 2026'
+# Authors
+# If you created a profile for a user (e.g. the default `admin` user), write the username (folder name) here
+# and it will be replaced with their full name and linked to their profile.
+authors:
+- M Upravitelev
+- V Solopova
+- J Yang
+- C Jakob
+- P Sahitaj
+- A Sahitaj
+- ...
+# Author notes (optional)
+author_notes:
+date: '2026-01-01T00:00:00Z'
+doi: ''
+# Schedule page publish date (NOT publication's date).
+publishDate: '2026-01-01T00:00:00Z'
+# Publication type.
+# Accepts a single type but formatted as a YAML list (for Hugo requirements).
+# Enter a publication type from the CSL standard.
+publication_types: ['manuscript']
+# Publication name and optional abbreviated publication name.
+publication: 'Proceedings of the 20th International Workshop on Semantic Evaluation (2026 …'
+publication_short:
+abstract: 
+# Summary. An optional shortened abstract.
+summary:
+tags: []
+# Display this page in the Featured widget?
+featured: false
+# Custom links (uncomment lines below)
+# links:
+# - name: Custom Link
+#   url: http://example.org
+url_pdf: ''
+url_code: ''
+url_dataset: ''
+url_poster: ''
+url_project: ''
+url_slides: ''
+url_source: ''
+url_video: ''
+# Featured image
+# To use, add an image named `featured.jpg/png` to your page's folder.
+image:
+  caption: ''
+  focal_point: ''
+  preview_only: false
+# Associated Projects (optional).
+#   Associate this publication with one or more of your projects.
+#   Simply enter your project's folder or file name without extension.
+#   E.g. `internal-project` references `content/project/internal-project/index.md`.
+#   Otherwise, set `projects: []`.
+projects: []
+# Slides (optional).
+#   Associate this publication with Markdown slides.
+#   Simply enter your slide deck's filename without extension.
+#   E.g. `slides: "example"` references `content/slides/example/index.md`.
+#   Otherwise, set `slides: ""`.
+slides: ""
+---

--- a/content/publication/how-much-is-your-instagram-data-worth-economic-perspective-o/index.md
+++ b/content/publication/how-much-is-your-instagram-data-worth-economic-perspective-o/index.md
@@ -1,0 +1,62 @@
+---
+title: 'How Much is Your Instagram Data Worth? Economic Perspective of Privacy in the Social Media Context'
+subtitle: 'Vera Schmitt, Paul Michel dit Ferrer, Arooj Anwar Khan, Ina Kern, Sebastian Möller - Privacy and Identity Management 2023'
+# Authors
+# If you created a profile for a user (e.g. the default `admin` user), write the username (folder name) here
+# and it will be replaced with their full name and linked to their profile.
+authors:
+- Vera Schmitt
+- Paul Michel dit Ferrer
+- Arooj Anwar Khan
+- Ina Kern
+- Sebastian Möller
+# Author notes (optional)
+author_notes:
+date: '2023-01-01T00:00:00Z'
+doi: ''
+# Schedule page publish date (NOT publication's date).
+publishDate: '2023-01-01T00:00:00Z'
+# Publication type.
+# Accepts a single type but formatted as a YAML list (for Hugo requirements).
+# Enter a publication type from the CSL standard.
+publication_types: ['paper-conference']
+# Publication name and optional abbreviated publication name.
+publication: 'Privacy and Identity Management'
+publication_short:
+abstract: 
+# Summary. An optional shortened abstract.
+summary:
+tags: []
+# Display this page in the Featured widget?
+featured: false
+# Custom links (uncomment lines below)
+# links:
+# - name: Custom Link
+#   url: http://example.org
+url_pdf: 'https://doi.org/10.1007/978-3-031-57978-3_19'
+url_code: ''
+url_dataset: ''
+url_poster: ''
+url_project: ''
+url_slides: ''
+url_source: ''
+url_video: ''
+# Featured image
+# To use, add an image named `featured.jpg/png` to your page's folder.
+image:
+  caption: ''
+  focal_point: ''
+  preview_only: false
+# Associated Projects (optional).
+#   Associate this publication with one or more of your projects.
+#   Simply enter your project's folder or file name without extension.
+#   E.g. `internal-project` references `content/project/internal-project/index.md`.
+#   Otherwise, set `projects: []`.
+projects: []
+# Slides (optional).
+#   Associate this publication with Markdown slides.
+#   Simply enter your slide deck's filename without extension.
+#   E.g. `slides: "example"` references `content/slides/example/index.md`.
+#   Otherwise, set `slides: ""`.
+slides: ""
+---

--- a/content/publication/improving-a-pupillometry-signal-through-video-luminance-modu/index.md
+++ b/content/publication/improving-a-pupillometry-signal-through-video-luminance-modu/index.md
@@ -1,0 +1,62 @@
+---
+title: 'Improving a Pupillometry Signal Through Video Luminance Modulation'
+subtitle: 'Leon Schreiber, Wafaa Wardah, Vera Schmitt, Sebastian Möller, Robert P. Spang - QoMEX 2024'
+# Authors
+# If you created a profile for a user (e.g. the default `admin` user), write the username (folder name) here
+# and it will be replaced with their full name and linked to their profile.
+authors:
+- Leon Schreiber
+- Wafaa Wardah
+- Vera Schmitt
+- Sebastian Möller
+- Robert P. Spang
+# Author notes (optional)
+author_notes:
+date: '2024-01-01T00:00:00Z'
+doi: ''
+# Schedule page publish date (NOT publication's date).
+publishDate: '2024-01-01T00:00:00Z'
+# Publication type.
+# Accepts a single type but formatted as a YAML list (for Hugo requirements).
+# Enter a publication type from the CSL standard.
+publication_types: ['paper-conference']
+# Publication name and optional abbreviated publication name.
+publication: 'QoMEX'
+publication_short:
+abstract: 
+# Summary. An optional shortened abstract.
+summary:
+tags: []
+# Display this page in the Featured widget?
+featured: false
+# Custom links (uncomment lines below)
+# links:
+# - name: Custom Link
+#   url: http://example.org
+url_pdf: 'https://doi.org/10.1109/QoMEX61742.2024.10598288'
+url_code: ''
+url_dataset: ''
+url_poster: ''
+url_project: ''
+url_slides: ''
+url_source: ''
+url_video: ''
+# Featured image
+# To use, add an image named `featured.jpg/png` to your page's folder.
+image:
+  caption: ''
+  focal_point: ''
+  preview_only: false
+# Associated Projects (optional).
+#   Associate this publication with one or more of your projects.
+#   Simply enter your project's folder or file name without extension.
+#   E.g. `internal-project` references `content/project/internal-project/index.md`.
+#   Otherwise, set `projects: []`.
+projects: []
+# Slides (optional).
+#   Associate this publication with Markdown slides.
+#   Simply enter your slide deck's filename without extension.
+#   E.g. `slides: "example"` references `content/slides/example/index.md`.
+#   Otherwise, set `slides: ""`.
+slides: ""
+---

--- a/content/publication/influence-of-privacy-knowledge-on-privacy-attitudes-in-the-d/index.md
+++ b/content/publication/influence-of-privacy-knowledge-on-privacy-attitudes-in-the-d/index.md
@@ -1,0 +1,58 @@
+---
+title: 'Influence of Privacy Knowledge on Privacy Attitudes in the Domain of Location-Based Services'
+subtitle: 'Vera Schmitt - Privacy and Identity Management 2022'
+# Authors
+# If you created a profile for a user (e.g. the default `admin` user), write the username (folder name) here
+# and it will be replaced with their full name and linked to their profile.
+authors:
+- Vera Schmitt
+# Author notes (optional)
+author_notes:
+date: '2022-01-01T00:00:00Z'
+doi: ''
+# Schedule page publish date (NOT publication's date).
+publishDate: '2022-01-01T00:00:00Z'
+# Publication type.
+# Accepts a single type but formatted as a YAML list (for Hugo requirements).
+# Enter a publication type from the CSL standard.
+publication_types: ['paper-conference']
+# Publication name and optional abbreviated publication name.
+publication: 'Privacy and Identity Management'
+publication_short:
+abstract: 
+# Summary. An optional shortened abstract.
+summary:
+tags: []
+# Display this page in the Featured widget?
+featured: false
+# Custom links (uncomment lines below)
+# links:
+# - name: Custom Link
+#   url: http://example.org
+url_pdf: 'https://doi.org/10.1007/978-3-031-31971-6_10'
+url_code: ''
+url_dataset: ''
+url_poster: ''
+url_project: ''
+url_slides: ''
+url_source: ''
+url_video: ''
+# Featured image
+# To use, add an image named `featured.jpg/png` to your page's folder.
+image:
+  caption: ''
+  focal_point: ''
+  preview_only: false
+# Associated Projects (optional).
+#   Associate this publication with one or more of your projects.
+#   Simply enter your project's folder or file name without extension.
+#   E.g. `internal-project` references `content/project/internal-project/index.md`.
+#   Otherwise, set `projects: []`.
+projects: []
+# Slides (optional).
+#   Associate this publication with Markdown slides.
+#   Simply enter your slide deck's filename without extension.
+#   E.g. `slides: "example"` references `content/slides/example/index.md`.
+#   Otherwise, set `slides: ""`.
+slides: ""
+---

--- a/content/publication/is-privacy-a-trait-or-a-state-examining-hangriness-and-its-i/index.md
+++ b/content/publication/is-privacy-a-trait-or-a-state-examining-hangriness-and-its-i/index.md
@@ -1,0 +1,61 @@
+---
+title: 'Is Privacy a Trait or a State? Examining Hangriness and its Influence on Individual''s Privacy Perception'
+subtitle: 'Vera Schmitt, Robert P. Spang, Wafaa Wardah, Sebastian Möller - MuC (Workshopband) 2023'
+# Authors
+# If you created a profile for a user (e.g. the default `admin` user), write the username (folder name) here
+# and it will be replaced with their full name and linked to their profile.
+authors:
+- Vera Schmitt
+- Robert P. Spang
+- Wafaa Wardah
+- Sebastian Möller
+# Author notes (optional)
+author_notes:
+date: '2023-01-01T00:00:00Z'
+doi: ''
+# Schedule page publish date (NOT publication's date).
+publishDate: '2023-01-01T00:00:00Z'
+# Publication type.
+# Accepts a single type but formatted as a YAML list (for Hugo requirements).
+# Enter a publication type from the CSL standard.
+publication_types: ['paper-conference']
+# Publication name and optional abbreviated publication name.
+publication: 'MuC (Workshopband)'
+publication_short:
+abstract: 
+# Summary. An optional shortened abstract.
+summary:
+tags: []
+# Display this page in the Featured widget?
+featured: false
+# Custom links (uncomment lines below)
+# links:
+# - name: Custom Link
+#   url: http://example.org
+url_pdf: 'https://doi.org/10.18420/muc2023-mci-ws11-377'
+url_code: ''
+url_dataset: ''
+url_poster: ''
+url_project: ''
+url_slides: ''
+url_source: ''
+url_video: ''
+# Featured image
+# To use, add an image named `featured.jpg/png` to your page's folder.
+image:
+  caption: ''
+  focal_point: ''
+  preview_only: false
+# Associated Projects (optional).
+#   Associate this publication with one or more of your projects.
+#   Simply enter your project's folder or file name without extension.
+#   E.g. `internal-project` references `content/project/internal-project/index.md`.
+#   Otherwise, set `projects: []`.
+projects: []
+# Slides (optional).
+#   Associate this publication with Markdown slides.
+#   Simply enter your slide deck's filename without extension.
+#   E.g. `slides: "example"` references `content/slides/example/index.md`.
+#   Otherwise, set `slides: ""`.
+slides: ""
+---

--- a/content/publication/is-your-surveillance-camera-app-watching-you-a-privacy-analy/index.md
+++ b/content/publication/is-your-surveillance-camera-app-watching-you-a-privacy-analy/index.md
@@ -1,0 +1,60 @@
+---
+title: 'Is Your Surveillance Camera App Watching You? A Privacy Analysis'
+subtitle: 'V Schmitt, J Nicholson, S Möller - Science and Information Conference, 1375-1393 2023'
+# Authors
+# If you created a profile for a user (e.g. the default `admin` user), write the username (folder name) here
+# and it will be replaced with their full name and linked to their profile.
+authors:
+- V Schmitt
+- J Nicholson
+- S Möller
+# Author notes (optional)
+author_notes:
+date: '2023-01-01T00:00:00Z'
+doi: ''
+# Schedule page publish date (NOT publication's date).
+publishDate: '2023-01-01T00:00:00Z'
+# Publication type.
+# Accepts a single type but formatted as a YAML list (for Hugo requirements).
+# Enter a publication type from the CSL standard.
+publication_types: ['manuscript']
+# Publication name and optional abbreviated publication name.
+publication: 'Science and Information Conference, 1375-1393'
+publication_short:
+abstract: 
+# Summary. An optional shortened abstract.
+summary:
+tags: []
+# Display this page in the Featured widget?
+featured: false
+# Custom links (uncomment lines below)
+# links:
+# - name: Custom Link
+#   url: http://example.org
+url_pdf: ''
+url_code: ''
+url_dataset: ''
+url_poster: ''
+url_project: ''
+url_slides: ''
+url_source: ''
+url_video: ''
+# Featured image
+# To use, add an image named `featured.jpg/png` to your page's folder.
+image:
+  caption: ''
+  focal_point: ''
+  preview_only: false
+# Associated Projects (optional).
+#   Associate this publication with one or more of your projects.
+#   Simply enter your project's folder or file name without extension.
+#   E.g. `internal-project` references `content/project/internal-project/index.md`.
+#   Otherwise, set `projects: []`.
+projects: []
+# Slides (optional).
+#   Associate this publication with Markdown slides.
+#   Simply enter your slide deck's filename without extension.
+#   E.g. `slides: "example"` references `content/slides/example/index.md`.
+#   Otherwise, set `slides: ""`.
+slides: ""
+---

--- a/content/publication/judge-circuits/index.md
+++ b/content/publication/judge-circuits/index.md
@@ -1,0 +1,70 @@
+---
+title: 'Judge Circuits'
+subtitle: 'Nils Feldhus, Tanja Baeumel, Elena Golimblevskaia, Qianli Wang, Van Bach Nguyen, Aaron Louis Eidt, Selin Kahvecioglu, Christopher Ebert, Wojciech Samek, Jing Yang, Vera Schmitt, Sebastian Möller, Simon Ostermann - CoRR 2026'
+# Authors
+# If you created a profile for a user (e.g. the default `admin` user), write the username (folder name) here
+# and it will be replaced with their full name and linked to their profile.
+authors:
+- Nils Feldhus
+- Tanja Baeumel
+- Elena Golimblevskaia
+- Qianli Wang
+- Van Bach Nguyen
+- Aaron Louis Eidt
+- Selin Kahvecioglu
+- Christopher Ebert
+- Wojciech Samek
+- Jing Yang
+- Vera Schmitt
+- Sebastian Möller
+- Simon Ostermann
+# Author notes (optional)
+author_notes:
+date: '2026-01-01T00:00:00Z'
+doi: ''
+# Schedule page publish date (NOT publication's date).
+publishDate: '2026-01-01T00:00:00Z'
+# Publication type.
+# Accepts a single type but formatted as a YAML list (for Hugo requirements).
+# Enter a publication type from the CSL standard.
+publication_types: ['article-journal']
+# Publication name and optional abbreviated publication name.
+publication: 'CoRR'
+publication_short:
+abstract: 
+# Summary. An optional shortened abstract.
+summary:
+tags: []
+# Display this page in the Featured widget?
+featured: false
+# Custom links (uncomment lines below)
+# links:
+# - name: Custom Link
+#   url: http://example.org
+url_pdf: 'https://doi.org/10.48550/arXiv.2605.16023'
+url_code: ''
+url_dataset: ''
+url_poster: ''
+url_project: ''
+url_slides: ''
+url_source: ''
+url_video: ''
+# Featured image
+# To use, add an image named `featured.jpg/png` to your page's folder.
+image:
+  caption: ''
+  focal_point: ''
+  preview_only: false
+# Associated Projects (optional).
+#   Associate this publication with one or more of your projects.
+#   Simply enter your project's folder or file name without extension.
+#   E.g. `internal-project` references `content/project/internal-project/index.md`.
+#   Otherwise, set `projects: []`.
+projects: []
+# Slides (optional).
+#   Associate this publication with Markdown slides.
+#   Simply enter your slide deck's filename without extension.
+#   E.g. `slides: "example"` references `content/slides/example/index.md`.
+#   Otherwise, set `slides: ""`.
+slides: ""
+---

--- a/content/publication/large-language-models-are-transformers-in-artificial-intelli-2/index.md
+++ b/content/publication/large-language-models-are-transformers-in-artificial-intelli-2/index.md
@@ -1,0 +1,64 @@
+---
+title: 'Large Language Models are Transformers in Artificial Intelligence, Industry, Education, and Society'
+subtitle: 'S Brüggenwirth, A Burchard, T Fingscheidt, HH Hoos, K Illgner, K Knop, ... -  2024'
+# Authors
+# If you created a profile for a user (e.g. the default `admin` user), write the username (folder name) here
+# and it will be replaced with their full name and linked to their profile.
+authors:
+- S Brüggenwirth
+- A Burchard
+- T Fingscheidt
+- HH Hoos
+- K Illgner
+- K Knop
+- ...
+# Author notes (optional)
+author_notes:
+date: '2024-01-01T00:00:00Z'
+doi: ''
+# Schedule page publish date (NOT publication's date).
+publishDate: '2024-01-01T00:00:00Z'
+# Publication type.
+# Accepts a single type but formatted as a YAML list (for Hugo requirements).
+# Enter a publication type from the CSL standard.
+publication_types: ['manuscript']
+# Publication name and optional abbreviated publication name.
+publication: ''
+publication_short:
+abstract: 
+# Summary. An optional shortened abstract.
+summary:
+tags: []
+# Display this page in the Featured widget?
+featured: false
+# Custom links (uncomment lines below)
+# links:
+# - name: Custom Link
+#   url: http://example.org
+url_pdf: ''
+url_code: ''
+url_dataset: ''
+url_poster: ''
+url_project: ''
+url_slides: ''
+url_source: ''
+url_video: ''
+# Featured image
+# To use, add an image named `featured.jpg/png` to your page's folder.
+image:
+  caption: ''
+  focal_point: ''
+  preview_only: false
+# Associated Projects (optional).
+#   Associate this publication with one or more of your projects.
+#   Simply enter your project's folder or file name without extension.
+#   E.g. `internal-project` references `content/project/internal-project/index.md`.
+#   Otherwise, set `projects: []`.
+projects: []
+# Slides (optional).
+#   Associate this publication with Markdown slides.
+#   Simply enter your slide deck's filename without extension.
+#   E.g. `slides: "example"` references `content/slides/example/index.md`.
+#   Otherwise, set `slides: ""`.
+slides: ""
+---

--- a/content/publication/large-language-models-are-transformers-in-artificial-intelli/index.md
+++ b/content/publication/large-language-models-are-transformers-in-artificial-intelli/index.md
@@ -1,0 +1,63 @@
+---
+title: 'Large Language Models are Transformers in Artificial Intelligence, Industry, Education, and Society VDE Position Paper'
+subtitle: 'S Brüggenwirth, A Burchard, T Fingscheidt, H Hoos, K Illgner, ... - VDE Verband der Elektrotechnik Elektronik Informationstechnik e. V. 2025'
+# Authors
+# If you created a profile for a user (e.g. the default `admin` user), write the username (folder name) here
+# and it will be replaced with their full name and linked to their profile.
+authors:
+- S Brüggenwirth
+- A Burchard
+- T Fingscheidt
+- H Hoos
+- K Illgner
+- ...
+# Author notes (optional)
+author_notes:
+date: '2025-01-01T00:00:00Z'
+doi: ''
+# Schedule page publish date (NOT publication's date).
+publishDate: '2025-01-01T00:00:00Z'
+# Publication type.
+# Accepts a single type but formatted as a YAML list (for Hugo requirements).
+# Enter a publication type from the CSL standard.
+publication_types: ['manuscript']
+# Publication name and optional abbreviated publication name.
+publication: 'VDE Verband der Elektrotechnik Elektronik Informationstechnik e. V.'
+publication_short:
+abstract: 
+# Summary. An optional shortened abstract.
+summary:
+tags: []
+# Display this page in the Featured widget?
+featured: false
+# Custom links (uncomment lines below)
+# links:
+# - name: Custom Link
+#   url: http://example.org
+url_pdf: ''
+url_code: ''
+url_dataset: ''
+url_poster: ''
+url_project: ''
+url_slides: ''
+url_source: ''
+url_video: ''
+# Featured image
+# To use, add an image named `featured.jpg/png` to your page's folder.
+image:
+  caption: ''
+  focal_point: ''
+  preview_only: false
+# Associated Projects (optional).
+#   Associate this publication with one or more of your projects.
+#   Simply enter your project's folder or file name without extension.
+#   E.g. `internal-project` references `content/project/internal-project/index.md`.
+#   Otherwise, set `projects: []`.
+projects: []
+# Slides (optional).
+#   Associate this publication with Markdown slides.
+#   Simply enter your slide deck's filename without extension.
+#   E.g. `slides: "example"` references `content/slides/example/index.md`.
+#   Otherwise, set `slides: ""`.
+slides: ""
+---

--- a/content/publication/monetary-valuation-of-privacy---analyzing-the-consistency-of/index.md
+++ b/content/publication/monetary-valuation-of-privacy---analyzing-the-consistency-of/index.md
@@ -1,0 +1,58 @@
+---
+title: 'Monetary Valuation of Privacy - Analyzing the Consistency of Valuation Methods and Their Influencing Factors'
+subtitle: 'Vera Schmitt -  2025'
+# Authors
+# If you created a profile for a user (e.g. the default `admin` user), write the username (folder name) here
+# and it will be replaced with their full name and linked to their profile.
+authors:
+- Vera Schmitt
+# Author notes (optional)
+author_notes:
+date: '2025-01-01T00:00:00Z'
+doi: ''
+# Schedule page publish date (NOT publication's date).
+publishDate: '2025-01-01T00:00:00Z'
+# Publication type.
+# Accepts a single type but formatted as a YAML list (for Hugo requirements).
+# Enter a publication type from the CSL standard.
+publication_types: ['book']
+# Publication name and optional abbreviated publication name.
+publication: ''
+publication_short:
+abstract: 
+# Summary. An optional shortened abstract.
+summary:
+tags: []
+# Display this page in the Featured widget?
+featured: false
+# Custom links (uncomment lines below)
+# links:
+# - name: Custom Link
+#   url: http://example.org
+url_pdf: 'https://doi.org/10.1007/978-3-031-84239-9'
+url_code: ''
+url_dataset: ''
+url_poster: ''
+url_project: ''
+url_slides: ''
+url_source: ''
+url_video: ''
+# Featured image
+# To use, add an image named `featured.jpg/png` to your page's folder.
+image:
+  caption: ''
+  focal_point: ''
+  preview_only: false
+# Associated Projects (optional).
+#   Associate this publication with one or more of your projects.
+#   Simply enter your project's folder or file name without extension.
+#   E.g. `internal-project` references `content/project/internal-project/index.md`.
+#   Otherwise, set `projects: []`.
+projects: []
+# Slides (optional).
+#   Associate this publication with Markdown slides.
+#   Simply enter your slide deck's filename without extension.
+#   E.g. `slides: "example"` references `content/slides/example/index.md`.
+#   Otherwise, set `slides: ""`.
+slides: ""
+---

--- a/content/publication/monetary-valuation-of-privacy/index.md
+++ b/content/publication/monetary-valuation-of-privacy/index.md
@@ -1,0 +1,58 @@
+---
+title: 'Monetary Valuation of Privacy'
+subtitle: 'V Schmitt - Springer https://doi.org/10.1007/978-3-031-84239-9 2025'
+# Authors
+# If you created a profile for a user (e.g. the default `admin` user), write the username (folder name) here
+# and it will be replaced with their full name and linked to their profile.
+authors:
+- V Schmitt
+# Author notes (optional)
+author_notes:
+date: '2025-01-01T00:00:00Z'
+doi: ''
+# Schedule page publish date (NOT publication's date).
+publishDate: '2025-01-01T00:00:00Z'
+# Publication type.
+# Accepts a single type but formatted as a YAML list (for Hugo requirements).
+# Enter a publication type from the CSL standard.
+publication_types: ['manuscript']
+# Publication name and optional abbreviated publication name.
+publication: 'Springer https://doi.org/10.1007/978-3-031-84239-9'
+publication_short:
+abstract: 
+# Summary. An optional shortened abstract.
+summary:
+tags: []
+# Display this page in the Featured widget?
+featured: false
+# Custom links (uncomment lines below)
+# links:
+# - name: Custom Link
+#   url: http://example.org
+url_pdf: ''
+url_code: ''
+url_dataset: ''
+url_poster: ''
+url_project: ''
+url_slides: ''
+url_source: ''
+url_video: ''
+# Featured image
+# To use, add an image named `featured.jpg/png` to your page's folder.
+image:
+  caption: ''
+  focal_point: ''
+  preview_only: false
+# Associated Projects (optional).
+#   Associate this publication with one or more of your projects.
+#   Simply enter your project's folder or file name without extension.
+#   E.g. `internal-project` references `content/project/internal-project/index.md`.
+#   Otherwise, set `projects: []`.
+projects: []
+# Slides (optional).
+#   Associate this publication with Markdown slides.
+#   Simply enter your slide deck's filename without extension.
+#   E.g. `slides: "example"` references `content/slides/example/index.md`.
+#   Otherwise, set `slides: ""`.
+slides: ""
+---

--- a/content/publication/multi-task-learning-for-german-text-readability-assessment/index.md
+++ b/content/publication/multi-task-learning-for-german-text-readability-assessment/index.md
@@ -1,0 +1,61 @@
+---
+title: 'Multi-task Learning for German Text Readability Assessment'
+subtitle: 'Salar Mohtaj, Vera Schmitt, Razieh Khamsehashari, Sebastian Möller - CLiC-it 2023'
+# Authors
+# If you created a profile for a user (e.g. the default `admin` user), write the username (folder name) here
+# and it will be replaced with their full name and linked to their profile.
+authors:
+- Salar Mohtaj
+- Vera Schmitt
+- Razieh Khamsehashari
+- Sebastian Möller
+# Author notes (optional)
+author_notes:
+date: '2023-01-01T00:00:00Z'
+doi: ''
+# Schedule page publish date (NOT publication's date).
+publishDate: '2023-01-01T00:00:00Z'
+# Publication type.
+# Accepts a single type but formatted as a YAML list (for Hugo requirements).
+# Enter a publication type from the CSL standard.
+publication_types: ['paper-conference']
+# Publication name and optional abbreviated publication name.
+publication: 'CLiC-it'
+publication_short:
+abstract: 
+# Summary. An optional shortened abstract.
+summary:
+tags: []
+# Display this page in the Featured widget?
+featured: false
+# Custom links (uncomment lines below)
+# links:
+# - name: Custom Link
+#   url: http://example.org
+url_pdf: 'https://ceur-ws.org/Vol-3596/paper36.pdf'
+url_code: ''
+url_dataset: ''
+url_poster: ''
+url_project: ''
+url_slides: ''
+url_source: ''
+url_video: ''
+# Featured image
+# To use, add an image named `featured.jpg/png` to your page's folder.
+image:
+  caption: ''
+  focal_point: ''
+  preview_only: false
+# Associated Projects (optional).
+#   Associate this publication with one or more of your projects.
+#   Simply enter your project's folder or file name without extension.
+#   E.g. `internal-project` references `content/project/internal-project/index.md`.
+#   Otherwise, set `projects: []`.
+projects: []
+# Slides (optional).
+#   Associate this publication with Markdown slides.
+#   Simply enter your slide deck's filename without extension.
+#   E.g. `slides: "example"` references `content/slides/example/index.md`.
+#   Otherwise, set `slides: ""`.
+slides: ""
+---

--- a/content/publication/polbix-detecting-llms-political-bias-in-fact-checking-throug/index.md
+++ b/content/publication/polbix-detecting-llms-political-bias-in-fact-checking-throug/index.md
@@ -1,0 +1,62 @@
+---
+title: 'PolBiX: Detecting LLMs'' Political Bias in Fact-Checking through X-phemisms'
+subtitle: 'Charlott Jakob, David Harbecke, Patrick Parschan, Pia Wenzel Neves, Vera Schmitt - EMNLP (Findings) 2025'
+# Authors
+# If you created a profile for a user (e.g. the default `admin` user), write the username (folder name) here
+# and it will be replaced with their full name and linked to their profile.
+authors:
+- Charlott Jakob
+- David Harbecke
+- Patrick Parschan
+- Pia Wenzel Neves
+- Vera Schmitt
+# Author notes (optional)
+author_notes:
+date: '2025-01-01T00:00:00Z'
+doi: ''
+# Schedule page publish date (NOT publication's date).
+publishDate: '2025-01-01T00:00:00Z'
+# Publication type.
+# Accepts a single type but formatted as a YAML list (for Hugo requirements).
+# Enter a publication type from the CSL standard.
+publication_types: ['paper-conference']
+# Publication name and optional abbreviated publication name.
+publication: 'EMNLP (Findings)'
+publication_short:
+abstract: 
+# Summary. An optional shortened abstract.
+summary:
+tags: []
+# Display this page in the Featured widget?
+featured: false
+# Custom links (uncomment lines below)
+# links:
+# - name: Custom Link
+#   url: http://example.org
+url_pdf: 'https://doi.org/10.18653/v1/2025.findings-emnlp.932'
+url_code: ''
+url_dataset: ''
+url_poster: ''
+url_project: ''
+url_slides: ''
+url_source: ''
+url_video: ''
+# Featured image
+# To use, add an image named `featured.jpg/png` to your page's folder.
+image:
+  caption: ''
+  focal_point: ''
+  preview_only: false
+# Associated Projects (optional).
+#   Associate this publication with one or more of your projects.
+#   Simply enter your project's folder or file name without extension.
+#   E.g. `internal-project` references `content/project/internal-project/index.md`.
+#   Otherwise, set `projects: []`.
+projects: []
+# Slides (optional).
+#   Associate this publication with Markdown slides.
+#   Simply enter your slide deck's filename without extension.
+#   E.g. `slides: "example"` references `content/slides/example/index.md`.
+#   Otherwise, set `slides: ""`.
+slides: ""
+---

--- a/content/publication/protect-and-extend---using-gans-for-synthetic-data-generatio/index.md
+++ b/content/publication/protect-and-extend---using-gans-for-synthetic-data-generatio/index.md
@@ -1,0 +1,62 @@
+---
+title: 'Protect and Extend - Using GANs for Synthetic Data Generation of Time-Series Medical Records'
+subtitle: 'Navid Ashrafi, Vera Schmitt, Robert P. Spang, Sebastian Möller, Jan-Niklas Voigt-Antons - QoMEX 2023'
+# Authors
+# If you created a profile for a user (e.g. the default `admin` user), write the username (folder name) here
+# and it will be replaced with their full name and linked to their profile.
+authors:
+- Navid Ashrafi
+- Vera Schmitt
+- Robert P. Spang
+- Sebastian Möller
+- Jan-Niklas Voigt-Antons
+# Author notes (optional)
+author_notes:
+date: '2023-01-01T00:00:00Z'
+doi: ''
+# Schedule page publish date (NOT publication's date).
+publishDate: '2023-01-01T00:00:00Z'
+# Publication type.
+# Accepts a single type but formatted as a YAML list (for Hugo requirements).
+# Enter a publication type from the CSL standard.
+publication_types: ['paper-conference']
+# Publication name and optional abbreviated publication name.
+publication: 'QoMEX'
+publication_short:
+abstract: 
+# Summary. An optional shortened abstract.
+summary:
+tags: []
+# Display this page in the Featured widget?
+featured: false
+# Custom links (uncomment lines below)
+# links:
+# - name: Custom Link
+#   url: http://example.org
+url_pdf: 'https://doi.org/10.1109/QoMEX58391.2023.10178496'
+url_code: ''
+url_dataset: ''
+url_poster: ''
+url_project: ''
+url_slides: ''
+url_source: ''
+url_video: ''
+# Featured image
+# To use, add an image named `featured.jpg/png` to your page's folder.
+image:
+  caption: ''
+  focal_point: ''
+  preview_only: false
+# Associated Projects (optional).
+#   Associate this publication with one or more of your projects.
+#   Simply enter your project's folder or file name without extension.
+#   E.g. `internal-project` references `content/project/internal-project/index.md`.
+#   Otherwise, set `projects: []`.
+projects: []
+# Slides (optional).
+#   Associate this publication with Markdown slides.
+#   Simply enter your slide deck's filename without extension.
+#   E.g. `slides: "example"` references `content/slides/example/index.md`.
+#   Otherwise, set `slides: ""`.
+slides: ""
+---

--- a/content/publication/rubin-news-polygraph-verbundvorhaben-movera-multimodal-orche/index.md
+++ b/content/publication/rubin-news-polygraph-verbundvorhaben-movera-multimodal-orche/index.md
@@ -1,0 +1,61 @@
+---
+title: 'RUBIN-news-polygraph-Verbundvorhaben: MOVERA-Multimodal Orchestration for Media-Content Verification; Teilvorhaben 3: TextBase: Text-basierte Analyseverfahren für Multi-Modale …'
+subtitle: 'V Solopova, V Schmitt, C Jakob, M Sebastian - Hannover: Technische Informationsbibliothek 2026'
+# Authors
+# If you created a profile for a user (e.g. the default `admin` user), write the username (folder name) here
+# and it will be replaced with their full name and linked to their profile.
+authors:
+- V Solopova
+- V Schmitt
+- C Jakob
+- M Sebastian
+# Author notes (optional)
+author_notes:
+date: '2026-01-01T00:00:00Z'
+doi: ''
+# Schedule page publish date (NOT publication's date).
+publishDate: '2026-01-01T00:00:00Z'
+# Publication type.
+# Accepts a single type but formatted as a YAML list (for Hugo requirements).
+# Enter a publication type from the CSL standard.
+publication_types: ['manuscript']
+# Publication name and optional abbreviated publication name.
+publication: 'Hannover: Technische Informationsbibliothek'
+publication_short:
+abstract: 
+# Summary. An optional shortened abstract.
+summary:
+tags: []
+# Display this page in the Featured widget?
+featured: false
+# Custom links (uncomment lines below)
+# links:
+# - name: Custom Link
+#   url: http://example.org
+url_pdf: ''
+url_code: ''
+url_dataset: ''
+url_poster: ''
+url_project: ''
+url_slides: ''
+url_source: ''
+url_video: ''
+# Featured image
+# To use, add an image named `featured.jpg/png` to your page's folder.
+image:
+  caption: ''
+  focal_point: ''
+  preview_only: false
+# Associated Projects (optional).
+#   Associate this publication with one or more of your projects.
+#   Simply enter your project's folder or file name without extension.
+#   E.g. `internal-project` references `content/project/internal-project/index.md`.
+#   Otherwise, set `projects: []`.
+projects: []
+# Slides (optional).
+#   Associate this publication with Markdown slides.
+#   Simply enter your slide deck's filename without extension.
+#   E.g. `slides: "example"` references `content/slides/example/index.md`.
+#   Otherwise, set `slides: ""`.
+slides: ""
+---

--- a/content/publication/signals-of-strain-using-biosignals-to-assess-fatigue-in-vide/index.md
+++ b/content/publication/signals-of-strain-using-biosignals-to-assess-fatigue-in-vide/index.md
@@ -1,0 +1,64 @@
+---
+title: 'Signals of Strain: Using Biosignals to Assess Fatigue in Video Conferencing'
+subtitle: 'Lucy V. Pagel, Tanja Kojic, Vera Schmitt, Wafaa Wardah, Philipp L. Harnisch, Sebastian Möller, Robert P. Spang - HCI (11) 2025'
+# Authors
+# If you created a profile for a user (e.g. the default `admin` user), write the username (folder name) here
+# and it will be replaced with their full name and linked to their profile.
+authors:
+- Lucy V. Pagel
+- Tanja Kojic
+- Vera Schmitt
+- Wafaa Wardah
+- Philipp L. Harnisch
+- Sebastian Möller
+- Robert P. Spang
+# Author notes (optional)
+author_notes:
+date: '2025-01-01T00:00:00Z'
+doi: ''
+# Schedule page publish date (NOT publication's date).
+publishDate: '2025-01-01T00:00:00Z'
+# Publication type.
+# Accepts a single type but formatted as a YAML list (for Hugo requirements).
+# Enter a publication type from the CSL standard.
+publication_types: ['paper-conference']
+# Publication name and optional abbreviated publication name.
+publication: 'HCI (11)'
+publication_short:
+abstract: 
+# Summary. An optional shortened abstract.
+summary:
+tags: []
+# Display this page in the Featured widget?
+featured: false
+# Custom links (uncomment lines below)
+# links:
+# - name: Custom Link
+#   url: http://example.org
+url_pdf: 'https://doi.org/10.1007/978-3-031-93718-7_8'
+url_code: ''
+url_dataset: ''
+url_poster: ''
+url_project: ''
+url_slides: ''
+url_source: ''
+url_video: ''
+# Featured image
+# To use, add an image named `featured.jpg/png` to your page's folder.
+image:
+  caption: ''
+  focal_point: ''
+  preview_only: false
+# Associated Projects (optional).
+#   Associate this publication with one or more of your projects.
+#   Simply enter your project's folder or file name without extension.
+#   E.g. `internal-project` references `content/project/internal-project/index.md`.
+#   Otherwise, set `projects: []`.
+projects: []
+# Slides (optional).
+#   Associate this publication with Markdown slides.
+#   Simply enter your slide deck's filename without extension.
+#   E.g. `slides: "example"` references `content/slides/example/index.md`.
+#   Otherwise, set `slides: ""`.
+slides: ""
+---

--- a/content/publication/the-5th-acm-international-workshop-on-multimedia-ai-against/index.md
+++ b/content/publication/the-5th-acm-international-workshop-on-multimedia-ai-against/index.md
@@ -1,0 +1,65 @@
+---
+title: 'The 5th ACM International Workshop on Multimedia AI against Disinformation (MAD''26)'
+subtitle: 'Dan-Cristian Stanciu, Symeon Papadopoulos, Giorgos Kordopatis-Zilos, Bogdan Ionescu, Adrian Popescu, Roberto Caldelli, Milica Gerhardt, Vera Schmitt - ICMR 2026'
+# Authors
+# If you created a profile for a user (e.g. the default `admin` user), write the username (folder name) here
+# and it will be replaced with their full name and linked to their profile.
+authors:
+- Dan-Cristian Stanciu
+- Symeon Papadopoulos
+- Giorgos Kordopatis-Zilos
+- Bogdan Ionescu
+- Adrian Popescu
+- Roberto Caldelli
+- Milica Gerhardt
+- Vera Schmitt
+# Author notes (optional)
+author_notes:
+date: '2026-01-01T00:00:00Z'
+doi: ''
+# Schedule page publish date (NOT publication's date).
+publishDate: '2026-01-01T00:00:00Z'
+# Publication type.
+# Accepts a single type but formatted as a YAML list (for Hugo requirements).
+# Enter a publication type from the CSL standard.
+publication_types: ['paper-conference']
+# Publication name and optional abbreviated publication name.
+publication: 'ICMR'
+publication_short:
+abstract: 
+# Summary. An optional shortened abstract.
+summary:
+tags: []
+# Display this page in the Featured widget?
+featured: false
+# Custom links (uncomment lines below)
+# links:
+# - name: Custom Link
+#   url: http://example.org
+url_pdf: 'https://doi.org/10.1145/3805622.3811237'
+url_code: ''
+url_dataset: ''
+url_poster: ''
+url_project: ''
+url_slides: ''
+url_source: ''
+url_video: ''
+# Featured image
+# To use, add an image named `featured.jpg/png` to your page's folder.
+image:
+  caption: ''
+  focal_point: ''
+  preview_only: false
+# Associated Projects (optional).
+#   Associate this publication with one or more of your projects.
+#   Simply enter your project's folder or file name without extension.
+#   E.g. `internal-project` references `content/project/internal-project/index.md`.
+#   Otherwise, set `projects: []`.
+projects: []
+# Slides (optional).
+#   Associate this publication with Markdown slides.
+#   Simply enter your slide deck's filename without extension.
+#   E.g. `slides: "example"` references `content/slides/example/index.md`.
+#   Otherwise, set `slides: ""`.
+slides: ""
+---

--- a/content/publication/through-a-compressed-lens-investigating-the-impact-of-quanti/index.md
+++ b/content/publication/through-a-compressed-lens-investigating-the-impact-of-quanti/index.md
@@ -1,0 +1,65 @@
+---
+title: 'Through a Compressed Lens: Investigating the Impact of Quantization on LLM Explainability and Interpretability'
+subtitle: 'Qianli Wang, Mingyang Wang, Nils Feldhus, Simon Ostermann, Yuan Cao, Hinrich Schütze, Sebastian Möller, Vera Schmitt - CoRR 2025'
+# Authors
+# If you created a profile for a user (e.g. the default `admin` user), write the username (folder name) here
+# and it will be replaced with their full name and linked to their profile.
+authors:
+- Qianli Wang
+- Mingyang Wang
+- Nils Feldhus
+- Simon Ostermann
+- Yuan Cao
+- Hinrich Schütze
+- Sebastian Möller
+- Vera Schmitt
+# Author notes (optional)
+author_notes:
+date: '2025-01-01T00:00:00Z'
+doi: ''
+# Schedule page publish date (NOT publication's date).
+publishDate: '2025-01-01T00:00:00Z'
+# Publication type.
+# Accepts a single type but formatted as a YAML list (for Hugo requirements).
+# Enter a publication type from the CSL standard.
+publication_types: ['article-journal']
+# Publication name and optional abbreviated publication name.
+publication: 'CoRR'
+publication_short:
+abstract: 
+# Summary. An optional shortened abstract.
+summary:
+tags: []
+# Display this page in the Featured widget?
+featured: false
+# Custom links (uncomment lines below)
+# links:
+# - name: Custom Link
+#   url: http://example.org
+url_pdf: 'https://doi.org/10.48550/arXiv.2505.13963'
+url_code: ''
+url_dataset: ''
+url_poster: ''
+url_project: ''
+url_slides: ''
+url_source: ''
+url_video: ''
+# Featured image
+# To use, add an image named `featured.jpg/png` to your page's folder.
+image:
+  caption: ''
+  focal_point: ''
+  preview_only: false
+# Associated Projects (optional).
+#   Associate this publication with one or more of your projects.
+#   Simply enter your project's folder or file name without extension.
+#   E.g. `internal-project` references `content/project/internal-project/index.md`.
+#   Otherwise, set `projects: []`.
+projects: []
+# Slides (optional).
+#   Associate this publication with Markdown slides.
+#   Simply enter your slide deck's filename without extension.
+#   E.g. `slides: "example"` references `content/slides/example/index.md`.
+#   Otherwise, set `slides: ""`.
+slides: ""
+---

--- a/content/publication/uncovering-temporal-framing-in-the-news/index.md
+++ b/content/publication/uncovering-temporal-framing-in-the-news/index.md
@@ -1,0 +1,67 @@
+---
+title: 'Uncovering Temporal Framing in the News'
+subtitle: 'Tarek Mahmoud, Veronika Solopova, Premtim Sahitaj, Ariana Sahitaj, Max Upravitelev, Mervat Abassy, Hana Fatima Shaikh, Neda Foroutan, Vera Schmitt, Preslav Nakov - ACL (1) 2026'
+# Authors
+# If you created a profile for a user (e.g. the default `admin` user), write the username (folder name) here
+# and it will be replaced with their full name and linked to their profile.
+authors:
+- Tarek Mahmoud
+- Veronika Solopova
+- Premtim Sahitaj
+- Ariana Sahitaj
+- Max Upravitelev
+- Mervat Abassy
+- Hana Fatima Shaikh
+- Neda Foroutan
+- Vera Schmitt
+- Preslav Nakov
+# Author notes (optional)
+author_notes:
+date: '2026-01-01T00:00:00Z'
+doi: ''
+# Schedule page publish date (NOT publication's date).
+publishDate: '2026-01-01T00:00:00Z'
+# Publication type.
+# Accepts a single type but formatted as a YAML list (for Hugo requirements).
+# Enter a publication type from the CSL standard.
+publication_types: ['paper-conference']
+# Publication name and optional abbreviated publication name.
+publication: 'ACL (1)'
+publication_short:
+abstract: 
+# Summary. An optional shortened abstract.
+summary:
+tags: []
+# Display this page in the Featured widget?
+featured: false
+# Custom links (uncomment lines below)
+# links:
+# - name: Custom Link
+#   url: http://example.org
+url_pdf: 'https://aclanthology.org/2026.acl-long.222/'
+url_code: ''
+url_dataset: ''
+url_poster: ''
+url_project: ''
+url_slides: ''
+url_source: ''
+url_video: ''
+# Featured image
+# To use, add an image named `featured.jpg/png` to your page's folder.
+image:
+  caption: ''
+  focal_point: ''
+  preview_only: false
+# Associated Projects (optional).
+#   Associate this publication with one or more of your projects.
+#   Simply enter your project's folder or file name without extension.
+#   E.g. `internal-project` references `content/project/internal-project/index.md`.
+#   Otherwise, set `projects: []`.
+projects: []
+# Slides (optional).
+#   Associate this publication with Markdown slides.
+#   Simply enter your slide deck's filename without extension.
+#   E.g. `slides: "example"` references `content/slides/example/index.md`.
+#   Otherwise, set `slides: ""`.
+slides: ""
+---

--- a/content/publication/what-is-your-location-privacy-worth-monetary-valuation-of-di/index.md
+++ b/content/publication/what-is-your-location-privacy-worth-monetary-valuation-of-di/index.md
@@ -1,0 +1,62 @@
+---
+title: 'What is Your Location Privacy Worth? Monetary Valuation of Different Location Types and Privacy Influencing Factors'
+subtitle: 'Vera Schmitt, Zhenni Li, Maija Poikela, Robert P. Spang, Sebastian Möller - WISEC 2023'
+# Authors
+# If you created a profile for a user (e.g. the default `admin` user), write the username (folder name) here
+# and it will be replaced with their full name and linked to their profile.
+authors:
+- Vera Schmitt
+- Zhenni Li
+- Maija Poikela
+- Robert P. Spang
+- Sebastian Möller
+# Author notes (optional)
+author_notes:
+date: '2023-01-01T00:00:00Z'
+doi: ''
+# Schedule page publish date (NOT publication's date).
+publishDate: '2023-01-01T00:00:00Z'
+# Publication type.
+# Accepts a single type but formatted as a YAML list (for Hugo requirements).
+# Enter a publication type from the CSL standard.
+publication_types: ['paper-conference']
+# Publication name and optional abbreviated publication name.
+publication: 'WISEC'
+publication_short:
+abstract: 
+# Summary. An optional shortened abstract.
+summary:
+tags: []
+# Display this page in the Featured widget?
+featured: false
+# Custom links (uncomment lines below)
+# links:
+# - name: Custom Link
+#   url: http://example.org
+url_pdf: 'https://doi.org/10.1145/3558482.3590180'
+url_code: ''
+url_dataset: ''
+url_poster: ''
+url_project: ''
+url_slides: ''
+url_source: ''
+url_video: ''
+# Featured image
+# To use, add an image named `featured.jpg/png` to your page's folder.
+image:
+  caption: ''
+  focal_point: ''
+  preview_only: false
+# Associated Projects (optional).
+#   Associate this publication with one or more of your projects.
+#   Simply enter your project's folder or file name without extension.
+#   E.g. `internal-project` references `content/project/internal-project/index.md`.
+#   Otherwise, set `projects: []`.
+projects: []
+# Slides (optional).
+#   Associate this publication with Markdown slides.
+#   Simply enter your slide deck's filename without extension.
+#   E.g. `slides: "example"` references `content/slides/example/index.md`.
+#   Otherwise, set `slides: ""`.
+slides: ""
+---

--- a/content/publication/willingness-to-pay-for-the-protection-of-different-data-type/index.md
+++ b/content/publication/willingness-to-pay-for-the-protection-of-different-data-type/index.md
@@ -1,0 +1,60 @@
+---
+title: 'Willingness to Pay for the Protection of Different Data Types'
+subtitle: 'Vera Schmitt, Maija Poikela, Sebastian Möller - MuC (Workshopband) 2021'
+# Authors
+# If you created a profile for a user (e.g. the default `admin` user), write the username (folder name) here
+# and it will be replaced with their full name and linked to their profile.
+authors:
+- Vera Schmitt
+- Maija Poikela
+- Sebastian Möller
+# Author notes (optional)
+author_notes:
+date: '2021-01-01T00:00:00Z'
+doi: ''
+# Schedule page publish date (NOT publication's date).
+publishDate: '2021-01-01T00:00:00Z'
+# Publication type.
+# Accepts a single type but formatted as a YAML list (for Hugo requirements).
+# Enter a publication type from the CSL standard.
+publication_types: ['paper-conference']
+# Publication name and optional abbreviated publication name.
+publication: 'MuC (Workshopband)'
+publication_short:
+abstract: 
+# Summary. An optional shortened abstract.
+summary:
+tags: []
+# Display this page in the Featured widget?
+featured: false
+# Custom links (uncomment lines below)
+# links:
+# - name: Custom Link
+#   url: http://example.org
+url_pdf: 'https://doi.org/10.18420/muc2021-mci-wsc-390'
+url_code: ''
+url_dataset: ''
+url_poster: ''
+url_project: ''
+url_slides: ''
+url_source: ''
+url_video: ''
+# Featured image
+# To use, add an image named `featured.jpg/png` to your page's folder.
+image:
+  caption: ''
+  focal_point: ''
+  preview_only: false
+# Associated Projects (optional).
+#   Associate this publication with one or more of your projects.
+#   Simply enter your project's folder or file name without extension.
+#   E.g. `internal-project` references `content/project/internal-project/index.md`.
+#   Otherwise, set `projects: []`.
+projects: []
+# Slides (optional).
+#   Associate this publication with Markdown slides.
+#   Simply enter your slide deck's filename without extension.
+#   E.g. `slides: "example"` references `content/slides/example/index.md`.
+#   Otherwise, set `slides: ""`.
+slides: ""
+---

--- a/content/publication/xplainlp-at-checkthat-2025-multilingual-subjectivity-detecti/index.md
+++ b/content/publication/xplainlp-at-checkthat-2025-multilingual-subjectivity-detecti/index.md
@@ -1,0 +1,65 @@
+---
+title: 'XplaiNLP at CheckThat! 2025: Multilingual Subjectivity Detection with Finetuned Transformers and Prompt-Based Inference with Large Language Models'
+subtitle: 'Ariana Sahitaj, Jiaao Li, Pia Wenzel Neves, Fedor Splitt, Premtim Sahitaj, Charlott Jakob, Veronika Solopova, Vera Schmitt - CLEF (Working Notes) 2025'
+# Authors
+# If you created a profile for a user (e.g. the default `admin` user), write the username (folder name) here
+# and it will be replaced with their full name and linked to their profile.
+authors:
+- Ariana Sahitaj
+- Jiaao Li
+- Pia Wenzel Neves
+- Fedor Splitt
+- Premtim Sahitaj
+- Charlott Jakob
+- Veronika Solopova
+- Vera Schmitt
+# Author notes (optional)
+author_notes:
+date: '2025-01-01T00:00:00Z'
+doi: ''
+# Schedule page publish date (NOT publication's date).
+publishDate: '2025-01-01T00:00:00Z'
+# Publication type.
+# Accepts a single type but formatted as a YAML list (for Hugo requirements).
+# Enter a publication type from the CSL standard.
+publication_types: ['paper-conference']
+# Publication name and optional abbreviated publication name.
+publication: 'CLEF (Working Notes)'
+publication_short:
+abstract: 
+# Summary. An optional shortened abstract.
+summary:
+tags: []
+# Display this page in the Featured widget?
+featured: false
+# Custom links (uncomment lines below)
+# links:
+# - name: Custom Link
+#   url: http://example.org
+url_pdf: 'https://ceur-ws.org/Vol-4038/paper_90.pdf'
+url_code: ''
+url_dataset: ''
+url_poster: ''
+url_project: ''
+url_slides: ''
+url_source: ''
+url_video: ''
+# Featured image
+# To use, add an image named `featured.jpg/png` to your page's folder.
+image:
+  caption: ''
+  focal_point: ''
+  preview_only: false
+# Associated Projects (optional).
+#   Associate this publication with one or more of your projects.
+#   Simply enter your project's folder or file name without extension.
+#   E.g. `internal-project` references `content/project/internal-project/index.md`.
+#   Otherwise, set `projects: []`.
+projects: []
+# Slides (optional).
+#   Associate this publication with Markdown slides.
+#   Simply enter your slide deck's filename without extension.
+#   E.g. `slides: "example"` references `content/slides/example/index.md`.
+#   Otherwise, set `slides: ""`.
+slides: ""
+---

--- a/content/publication/xplainlp-at-semeval-2026-task-1-bvahaha-benign-violation-alg/index.md
+++ b/content/publication/xplainlp-at-semeval-2026-task-1-bvahaha-benign-violation-alg/index.md
@@ -1,0 +1,62 @@
+---
+title: 'XplaiNLP at SemEval-2026 task 1: BVAHAHA-benign violation algorithm for humor and harmless absurdity'
+subtitle: 'B Bubus, N Soyal, V Schmitt, N Feldhus, V Solopova - Proceedings of the 20th International Workshop on Semantic Evaluation (2026 … 2026'
+# Authors
+# If you created a profile for a user (e.g. the default `admin` user), write the username (folder name) here
+# and it will be replaced with their full name and linked to their profile.
+authors:
+- B Bubus
+- N Soyal
+- V Schmitt
+- N Feldhus
+- V Solopova
+# Author notes (optional)
+author_notes:
+date: '2026-01-01T00:00:00Z'
+doi: ''
+# Schedule page publish date (NOT publication's date).
+publishDate: '2026-01-01T00:00:00Z'
+# Publication type.
+# Accepts a single type but formatted as a YAML list (for Hugo requirements).
+# Enter a publication type from the CSL standard.
+publication_types: ['manuscript']
+# Publication name and optional abbreviated publication name.
+publication: 'Proceedings of the 20th International Workshop on Semantic Evaluation (2026 …'
+publication_short:
+abstract: 
+# Summary. An optional shortened abstract.
+summary:
+tags: []
+# Display this page in the Featured widget?
+featured: false
+# Custom links (uncomment lines below)
+# links:
+# - name: Custom Link
+#   url: http://example.org
+url_pdf: ''
+url_code: ''
+url_dataset: ''
+url_poster: ''
+url_project: ''
+url_slides: ''
+url_source: ''
+url_video: ''
+# Featured image
+# To use, add an image named `featured.jpg/png` to your page's folder.
+image:
+  caption: ''
+  focal_point: ''
+  preview_only: false
+# Associated Projects (optional).
+#   Associate this publication with one or more of your projects.
+#   Simply enter your project's folder or file name without extension.
+#   E.g. `internal-project` references `content/project/internal-project/index.md`.
+#   Otherwise, set `projects: []`.
+projects: []
+# Slides (optional).
+#   Associate this publication with Markdown slides.
+#   Simply enter your slide deck's filename without extension.
+#   E.g. `slides: "example"` references `content/slides/example/index.md`.
+#   Otherwise, set `slides: ""`.
+slides: ""
+---


### PR DESCRIPTION
## Summary

This PR adds the latest publications to the XplaiNLP website.

### Changes

- Added 30 new publication pages under `content/publication/`.
- Generated using the publication synchronization pipeline.
- Verified that the Hugo site builds successfully and the new publication pages render correctly.

No existing publication pages were modified.