### PR TITLE
Add publication synchronization tool

### DIFF
--- a/publication-sync/README.md
+++ b/publication-sync/README.md
@@ -1,0 +1,165 @@
+# Publication Sync Pipeline — VeraXtract Website
+
+Keeps `content/publication/` on the group website in sync with the latest publications using **DBLP**, **Semantic Scholar**, and **Google Scholar**.
+
+---
+
+# Quick Start
+
+1. Clone this repository.
+2. Install the required Python packages.
+3. Edit **`config.py`**.
+4. Run:
+
+```bash
+python dblp_semantic_scraper.py
+```
+
+For an occasional audit against Google Scholar:
+
+```bash
+python cross_check_scholar.py
+```
+
+Finally, before copying anything into the website repository:
+
+```bash
+python sanity_check.py
+```
+
+---
+
+# Configuration
+
+All user-editable settings are contained in a single file:
+
+```text
+config.py
+```
+
+The remaining Python scripts automatically import these settings—you should never need to edit the scripts themselves.
+
+The configuration is organised into four sections:
+
+## Publication Sources
+
+- DBLP profile URL
+- Semantic Scholar author ID
+- Google Scholar profile URL
+
+## Directories
+
+- Website repository root
+- Output directory
+
+All reports and generated publication folders are derived automatically from these directories.
+
+## Filters
+
+- `YEAR`
+- `MIN_YEAR`
+- `MAX_YEAR`
+
+Leave them as `None` to process every publication.
+
+## Runtime Options
+
+- Google Scholar headless mode
+- HTTP request headers
+- Matching threshold
+- Other optional runtime settings
+
+---
+
+# Scripts
+
+## 1. `dblp_semantic_scraper.py`
+
+The primary synchronization script. This is the script you'll run most often.
+
+It:
+
+- downloads publications from DBLP and Semantic Scholar,
+- merges metadata,
+- compares the results against the website,
+- generates publication folders,
+- produces missing-paper reports,
+- generates per-author review requests.
+
+---
+
+## 2. `google_scholar_citations.py`
+
+Helper module used to retrieve citation statistics from a Google Scholar profile.
+
+Normally this is **not** executed directly. It is imported by `cross_check_scholar.py`.
+
+Because Google Scholar has no public API, this script should only be used occasionally.
+
+---
+
+## 3. `cross_check_scholar.py`
+
+An occasional audit step.
+
+It compares Google Scholar against the DBLP/Semantic Scholar dataset and identifies publications that may be missing from the synchronization pipeline.
+
+Use this periodically—not as part of a scheduled workflow.
+
+---
+
+## 4. `sanity_check.py`
+
+The final verification step.
+
+Run this after generating publication folders and before copying them into the website repository.
+
+The script performs several consistency checks, including:
+
+- duplicate generated papers,
+- papers already present in the website,
+- malformed or placeholder metadata.
+
+The script is completely **read-only**.
+
+If every check passes, the generated folders are ready for manual review and Git submission.
+
+---
+
+# Recommended Workflow
+
+```text
+dblp_semantic_scraper.py
+        │
+        ▼
+Review generated papers
+        │
+        ▼
+cross_check_scholar.py      (optional)
+        │
+        ▼
+Review Scholar-only papers
+        │
+        ▼
+sanity_check.py
+        │
+        ▼
+Copy into content/publication/
+        │
+        ▼
+Git commit → Push → Pull Request
+```
+
+## Requirements
+
+- Python 3.11+
+- Google Chrome (required only for Google Scholar scraping)
+
+The main synchronization script (`dblp_semantic_scraper.py`) does **not** require Chrome.
+
+Chrome is only needed when running:
+
+- `cross_check_scholar.py`
+- `google_scholar_citations.py`
+
+If ChromeDriver reports a version mismatch, update Chrome or set the appropriate `version_main` in `google_scholar_citations.py`.

--- a/publication-sync/config.py
+++ b/publication-sync/config.py
@@ -1,0 +1,150 @@
+from dataclasses import dataclass
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parent
+PROJECT_ROOT = ROOT.parent.parent
+
+
+@dataclass(frozen=True)
+class Config:
+    # ------------------------------------------------------------------
+    # Publication Sources
+    # ------------------------------------------------------------------
+
+    # ------------------------------------------------------------------
+    # Google Scholar
+    # ------------------------------------------------------------------
+    #
+    # Google Scholar scraping requires Google Chrome to be installed.
+    #
+    # The scraper uses Selenium together with ChromeDriver to automate
+    # the browser. If Chrome is not installed, or if the installed
+    # Chrome version is incompatible with the downloaded ChromeDriver,
+    # the Google Scholar scripts may fail to launch.
+    #
+    # If you encounter a Chrome/ChromeDriver version mismatch, set
+    # `version_main=<your Chrome major version>` in
+    # `google_scholar_citations.py`.
+    #
+    # These settings are only used by:
+    #   - google_scholar_citations.py
+    #   - cross_check_scholar.py
+    #
+    google_scholar_profile_url: str
+
+
+    dblp_url: str
+    semantic_scholar_id: str | None
+
+
+
+    # ------------------------------------------------------------------
+    # Root Directories
+    # ------------------------------------------------------------------
+    website_root: Path
+    output_root: Path
+
+    # ------------------------------------------------------------------
+    # Options
+    # ------------------------------------------------------------------
+    generate_missing_folders: bool = True
+
+
+
+
+    # ------------------------------------------------------------------
+    # Filters
+    # ------------------------------------------------------------------
+    year: int | None = None
+    min_year: int | None = None
+    max_year: int | None = None
+
+    # ------------------------------------------------------------------
+    # Matching
+    # ------------------------------------------------------------------
+    arxiv_similarity_threshold: float = 0.7
+
+    # ------------------------------------------------------------------
+    # Networking
+    # ------------------------------------------------------------------
+    http_headers: dict[str, str] | None = None
+
+
+    # ------------------------------------------------------------------
+    # Google Scholar Specific Configs
+    # ------------------------------------------------------------------
+
+    headless: bool = True
+    click_delay_seconds: int = 2
+    max_show_more_clicks: int = 20
+
+
+    # ------------------------------------------------------------------
+    # Derived Paths (no need for users to edit these)
+    # ------------------------------------------------------------------
+    @property
+    def existing_site_dir(self) -> Path:
+        return self.website_root / "content" / "publication"
+
+    @property
+    def missing_report_path(self) -> Path:
+        return self.output_root / "missing_publications.md"
+
+    @property
+    def missing_papers_dir(self) -> Path:
+        return self.output_root / "missing_papers"
+
+    @property
+    def scholar_output_json(self) -> Path:
+        return self.output_root / "scholar_citations.json"
+
+    @property
+    def scholar_flagged_report_path(self) -> Path:
+        return self.output_root / "scholar_only_flagged.md"
+
+# ======================================================================
+# User Configuration
+# Edit only this section.
+# ======================================================================
+
+cfg = Config(
+    # DBLP profile URL
+    dblp_url="https://dblp.org/pid/295/6533.html",
+
+    # Semantic Scholar author ID (set to None to disable)
+    semantic_scholar_id="2114572998",
+
+    # Path to the cloned website repository.
+    #
+    # Example:
+    # website_root = Path("/path/to/VeraXtract-Website")
+    #
+    # The directory must contain:
+    #   content/
+    #   content/publication/
+    #   content/authors/
+    website_root = Path("/Users/swarnadeep/Riju/Code/academic/XplaiNLP/xplainlp.github.io"),
+    #website_root = ROOT / "website"
+
+    # Directory where generated reports and folders will be written.
+    output_root = PROJECT_ROOT / "data" / "output_2",
+
+    # Generate folders for missing publications
+    generate_missing_folders=True,
+
+    # Filter publications (leave as None to disable)
+    year=None,
+    min_year=None,
+    max_year=None,
+
+    # Similarity threshold for matching arXiv preprints
+    arxiv_similarity_threshold=0.7,
+
+    http_headers={
+        "User-Agent": "lab-website-publication-sync/1.0",
+    },
+
+    google_scholar_profile_url="https://scholar.google.com/citations?user=pKbJC10AAAAJ&hl=en",
+
+)

--- a/publication-sync/cross_check_scholar.py
+++ b/publication-sync/cross_check_scholar.py
@@ -1,0 +1,156 @@
+#!/usr/bin/env python3
+"""
+Cross-check Vera's DBLP+Semantic Scholar publication list AND the existing
+website against her Google Scholar profile, and flag any papers Scholar
+has that neither source caught.
+
+DBLP + Semantic Scholar remain the source of truth for the website.
+Google Scholar is used here ONLY as an occasional audit pass -- to catch
+coverage gaps (e.g. a thesis, a non-CS venue, a very fresh preprint) that
+DBLP/S2 might have missed. This script does not modify anything in
+EXISTING_SITE_DIR; it only writes a report + optional ready-to-review
+folders for the flagged (Scholar-only, not-yet-on-site) papers.
+
+A paper is only flagged if it is on Scholar AND:
+  - NOT found via DBLP/Semantic Scholar, AND
+  - NOT already present on the site
+
+This means the output of this script and the output of
+dblp_semantic_scraper.py are disjoint (one requires being known via
+DBLP/S2, the other requires NOT being known via DBLP/S2) -- so both can
+safely write into the SAME final output directory (FINAL_PAPERS_DIR)
+without overwriting or duplicating each other's folders.
+
+Requires both sibling scripts to be in the SAME directory as this one:
+    dblp_semantic_scraper.py     (DBLP + Semantic Scholar fetch/merge/site-diff logic)
+    google_scholar_citations.py  (Google Scholar profile scraping logic)
+
+Requires: pip install requests pyyaml undetected-chromedriver selenium
+
+Usage:
+    python cross_check_scholar.py
+
+Reminder: Google Scholar has no public API and disallows scraping in
+its ToS. Run this occasionally / by hand when you actually want an
+audit, not on a schedule or repeatedly in a short window.
+"""
+
+import sys
+import time
+from config import cfg
+
+import dblp_semantic_scraper as sync           # DBLP + Semantic Scholar + site-diff logic
+import google_scholar_citations as gs           # Google Scholar profile scraping logic
+
+# ----------------------------- CONFIG -----------------------------
+DBLP_URL = cfg.dblp_url #"https://dblp.org/pid/295/6533.html"
+SEMANTIC_SCHOLAR_ID = cfg.semantic_scholar_id #"2114572998"
+SCHOLAR_PROFILE_URL = cfg.google_scholar_profile_url#"https://scholar.google.com/citations?user=pKbJC10AAAAJ&hl=en"
+
+# Same site path used by dblp_semantic_scraper.py -- needed here too so we
+# don't flag papers that are already on the site.
+EXISTING_SITE_DIR = cfg.existing_site_dir #"/Users/swarnadeep/Riju/Code/academic/XplaiNLP/xplainlp.github.io/content/publication"
+
+FLAGGED_REPORT_PATH = cfg.scholar_flagged_report_path #"/Users/swarnadeep/Riju/Code/academic/XplaiNLP/scrapper/data/output/scholar_only_flagged.md"
+
+# Same directory dblp_semantic_scraper.py writes its missing-paper folders
+# to. Since the two scripts' outputs are disjoint (see module docstring),
+# writing to the same directory gives you ONE final folder to review and
+# copy into content/publication/, combining both loops' findings.
+FINAL_PAPERS_DIR = cfg.missing_papers_dir #"/Users/swarnadeep/Riju/Code/academic/XplaiNLP/scrapper/data/output/missing_papers"
+GENERATE_FLAGGED_FOLDERS = cfg.generate_missing_folders #True
+# --------------------------------------------------------------------
+
+
+def scholar_pub_to_core_format(scholar_pub: dict) -> dict:
+    """Convert a Google-Scholar-scraped publication into the same dict
+    shape used by dblp_semantic_scraper.py, so it can go through the same
+    build_index_md() / write_paper_folders() logic.
+
+    NOTE: Scholar author names are often abbreviated (e.g. "V Schmitt"
+    instead of "Vera Schmitt") -- worth fixing up by hand if you use
+    the generated folder, since DBLP/S2 entries use full names.
+    """
+    authors = [a.strip() for a in (scholar_pub.get("authors_raw") or "").split(",") if a.strip()]
+    return {
+        "title": scholar_pub.get("title") or "Untitled",
+        "authors": authors,
+        "year": scholar_pub.get("year") or None,
+        "venue": scholar_pub.get("venue_raw") or None,
+        "link": None,   # Scholar's profile table doesn't expose a direct paper link
+        "doi": None,
+        "abstract": None,
+        "type": None,   # unknown -> falls back to DEFAULT_PUBLICATION_TYPE in build_index_md
+        "source": "google_scholar",
+        "citations": scholar_pub.get("citations", 0),
+    }
+
+
+def main():
+    # 1. Source of truth: DBLP + Semantic Scholar
+    print(f"Fetching DBLP publications from {DBLP_URL} ...", file=sys.stderr)
+    dblp_pubs = sync.fetch_dblp(DBLP_URL)
+    print(f"  -> {len(dblp_pubs)} entries from DBLP", file=sys.stderr)
+
+    s2_pubs = []
+    if SEMANTIC_SCHOLAR_ID:
+        print(f"Fetching Semantic Scholar publications for author {SEMANTIC_SCHOLAR_ID} ...", file=sys.stderr)
+        s2_pubs = sync.fetch_semantic_scholar(SEMANTIC_SCHOLAR_ID)
+        print(f"  -> {len(s2_pubs)} entries from Semantic Scholar", file=sys.stderr)
+
+    merged = sync.merge_publications(dblp_pubs, s2_pubs)
+    known_titles = {sync.normalize_title(p["title"]) for p in merged}
+    print(f"DBLP+S2 combined: {len(merged)} unique publications known", file=sys.stderr)
+
+    # 2. What's already on the site (so we don't re-flag it)
+    print(f"Scanning existing site publications in {EXISTING_SITE_DIR} ...", file=sys.stderr)
+    existing_titles = sync.parse_existing_titles(EXISTING_SITE_DIR)
+    print(f"  -> {len(existing_titles)} existing papers found on site", file=sys.stderr)
+
+    # 3. Audit pass: Google Scholar profile
+    print(f"Launching browser to fetch {SCHOLAR_PROFILE_URL} ...", file=sys.stderr)
+    browser = gs.get_browser()
+    try:
+        browser.get(SCHOLAR_PROFILE_URL)
+        time.sleep(3)
+        gs.expand_all_publications(browser)
+        scholar_pubs = gs.parse_publications(browser)
+    finally:
+        browser.quit()
+    print(f"  -> {len(scholar_pubs)} entries from Google Scholar", file=sys.stderr)
+
+    # 4. Flag anything on Scholar that's neither known via DBLP/S2 NOR
+    # already on the site.
+    flagged_raw = [
+        p
+        for p in scholar_pubs
+        if p["normalized_title"] not in known_titles
+        and p["normalized_title"] not in existing_titles
+    ]
+    flagged = [scholar_pub_to_core_format(p) for p in flagged_raw]
+    print(
+        f"Flagged (on Scholar, not found via DBLP/S2, not already on site): {len(flagged)}",
+        file=sys.stderr,
+    )
+
+    # 5. Write report
+    report = sync.to_markdown(
+        flagged, header="# On Google Scholar but NOT found via DBLP/S2 or the site"
+    )
+    FLAGGED_REPORT_PATH.write_text(report,encoding="utf-8")
+    print(f"Wrote flagged report to {FLAGGED_REPORT_PATH}", file=sys.stderr)
+
+    # 6. Optionally generate index.md-ready folders for just the flagged
+    # papers, into the SAME final directory dblp_semantic_scraper.py uses.
+    if GENERATE_FLAGGED_FOLDERS and flagged:
+        sync.write_paper_folders(flagged, FINAL_PAPERS_DIR)
+        print(
+            "NOTE: flagged folders have limited metadata (no link/doi/abstract, "
+            "and author names may be abbreviated as Scholar shows them). "
+            "Review and fill these in by hand before adding to the site.",
+            file=sys.stderr,
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/publication-sync/dblp_semantic_scraper.py
+++ b/publication-sync/dblp_semantic_scraper.py
@@ -1,0 +1,552 @@
+#!/usr/bin/env python3
+"""
+Publication fetcher + missing-paper detector for lab website updates.
+
+Pulls publication metadata from DBLP (primary source, curated) and
+optionally Semantic Scholar (to catch very recent items DBLP hasn't
+indexed yet), then:
+
+  1. Scans the EXISTING website's publication folders (EXISTING_SITE_DIR),
+     reads each index.md's `title:` field, and diffs it against the
+     fetched papers (fetched in full from DBLP/S2 -- neither has a "what's
+     new" query, so the full list has to be pulled every run to compute
+     this diff) to find which ones are NOT yet on the site.
+  2. Writes a Markdown report of just the missing papers (MISSING_REPORT_PATH)
+     and, if GENERATE_MISSING_FOLDERS is True, generates ready-to-use
+     folder+index.md entries for ONLY the missing papers (MISSING_PAPERS_DIR)
+     so you can review and drop them straight into the site repo.
+
+Configure the CONFIG block below and run:
+    pip install requests pyyaml
+    python scholar_scraper.py
+
+Notes:
+    - DBLP: any profile URL works; the script converts it to the
+      XML export endpoint (append .xml).
+    - Semantic Scholar author ID: the numeric ID at the end of the
+      profile URL, e.g. https://www.semanticscholar.org/author/Vera-Schmitt/1234567
+      -> id is "1234567". Set to None to skip it.
+    - This script does NOT touch Google Scholar. Scholar has no public
+      API, disallows scraping in its ToS, and aggressively rate-limits/
+      CAPTCHAs automated requests. DBLP + Semantic Scholar cover the same
+      metadata without those problems.
+    - Year filter: set YEAR for a single year, or MIN_YEAR/MAX_YEAR for
+      a range. Leave all three as None for no filtering.
+    - Matching for the "missing" diff is done on a normalized title
+      (lowercased, alphanumeric-only), so minor punctuation/spacing
+      differences between DBLP/S2 and the site won't cause false positives.
+      Still, always eyeball the missing-report before bulk-adding folders --
+      title drift (e.g. a preprint title vs. camera-ready title) can cause
+      a paper to look "missing" when it's actually already there.
+"""
+
+import difflib
+import os
+import re
+import sys
+import xml.etree.ElementTree as ET
+from pathlib import Path
+from os import PathLike
+import requests
+import yaml
+from config import cfg
+
+# ----------------------------- CONFIG -----------------------------
+DBLP_URL = cfg.dblp_url #"https://dblp.org/pid/295/6533.html"
+SEMANTIC_SCHOLAR_ID = cfg.dblp_url #"2114572998"
+
+# Path to the website repo's existing publications folder
+# (one subfolder per paper, each containing an index.md).
+EXISTING_SITE_DIR = cfg.existing_site_dir #"/Users/swarnadeep/Riju/Code/academic/XplaiNLP/xplainlp.github.io/content/publication"
+
+MISSING_REPORT_PATH = cfg.missing_report_path #"/Users/swarnadeep/Riju/Code/academic/XplaiNLP/scrapper/data/output/missing_publications.md"
+MISSING_PAPERS_DIR = cfg.missing_papers_dir #"/Users/swarnadeep/Riju/Code/academic/XplaiNLP/scrapper/data/output/missing_papers"
+GENERATE_MISSING_FOLDERS = cfg.generate_missing_folders #True  # if True, also write ready-to-use folders for missing papers only
+
+YEAR = cfg.year             # e.g. 2025 -> only that year (overrides MIN_YEAR/MAX_YEAR)
+MIN_YEAR = cfg.min_year          # e.g. 2023 -> 2023 onward
+MAX_YEAR = cfg.max_year          # e.g. 2024 -> up to and including 2024
+
+# Minimum title-similarity ratio (0-1) for treating an arXiv/preprint entry
+# and a real-venue entry as the SAME paper. Only applies when one side is a
+# preprint venue and the other isn't -- two real, distinct papers are never
+# merged by this, no matter how similar their titles look.
+ARXIV_TITLE_SIMILARITY_THRESHOLD = cfg.arxiv_similarity_threshold #0.7
+# --------------------------------------------------------------------
+
+DBLP_HEADERS = cfg.http_headers#{"User-Agent": "lab-website-publication-sync/1.0"}
+
+# DBLP appends a 4-digit disambiguation suffix to author names that collide
+# with another researcher of the same name, e.g. "Sebastian Möller 0001".
+# This is meant to stay internal to DBLP and should be stripped for display.
+_DBLP_AUTHOR_SUFFIX_RE = re.compile(r"\s+\d{4}$")
+
+
+def clean_author_name(name: str) -> str:
+    return _DBLP_AUTHOR_SUFFIX_RE.sub("", name.strip())
+
+# DBLP entry tag -> CSL publication_types value used by Hugo Academic
+PUBLICATION_TYPE_MAP = {
+    "article": "article-journal",
+    "inproceedings": "paper-conference",
+    "incollection": "chapter",
+    "book": "book",
+    "phdthesis": "thesis",
+    "mastersthesis": "thesis",
+}
+DEFAULT_PUBLICATION_TYPE = "manuscript"
+
+
+def dblp_xml_url(profile_url: str) -> str:
+    """Convert a DBLP profile URL (.html or bare) into its .xml export URL."""
+    if profile_url.endswith(".xml"):
+        return profile_url
+    if profile_url.endswith(".html"):
+        return profile_url[: -len(".html")] + ".xml"
+    return profile_url.rstrip("/") + ".xml"
+
+
+# DBLP indexes more than just papers under a person's profile -- datasets,
+# software, homepages, and edited-volume records show up as different XML
+# tags too. Only these tags represent an actual authored publication;
+# anything else (e.g. "data" for datasets/software, "www" for homepages,
+# "editor" for edited volumes, "proceedings" for a volume itself) is
+# excluded so it never enters the pipeline as if it were a paper.
+_DBLP_PAPER_TAGS = {
+    "article", "inproceedings", "incollection", "book",
+    "phdthesis", "mastersthesis",
+}
+
+
+def fetch_dblp(profile_url: str) -> list[dict]:
+    url = dblp_xml_url(profile_url)
+    resp = requests.get(url, headers=DBLP_HEADERS, timeout=30)
+    resp.raise_for_status()
+    root = ET.fromstring(resp.content)
+
+    pubs = []
+    skipped_non_paper = 0
+    for r in root.findall(".//r"):
+        for entry in list(r):
+            if entry.tag not in _DBLP_PAPER_TAGS:
+                skipped_non_paper += 1
+                continue
+
+            title_el = entry.find("title")
+            if title_el is None or not title_el.text:
+                continue
+            authors = [clean_author_name(a.text) for a in entry.findall("author") if a.text]
+            year_el = entry.find("year")
+            venue_el = entry.find("journal")
+            if venue_el is None:
+                venue_el = entry.find("booktitle")
+            ee_el = entry.find("ee")
+            url_el = entry.find("url")
+
+            pubs.append(
+                {
+                    "title": title_el.text.strip().rstrip("."),
+                    "authors": authors,
+                    "year": year_el.text if year_el is not None else None,
+                    "venue": venue_el.text if venue_el is not None else None,
+                    "link": ee_el.text if ee_el is not None else (
+                        f"https://dblp.org/{url_el.text}" if url_el is not None else None
+                    ),
+                    "doi": None,
+                    "abstract": None,
+                    "type": entry.tag,
+                    "source": "dblp",
+                }
+            )
+
+    if skipped_non_paper:
+        print(
+            f"  (excluded {skipped_non_paper} non-paper DBLP record(s): "
+            f"datasets, software, homepages, edited volumes, etc.)",
+            file=sys.stderr,
+        )
+
+    return pubs
+
+
+def fetch_semantic_scholar(author_id: str) -> list[dict]:
+    url = f"https://api.semanticscholar.org/graph/v1/author/{author_id}/papers"
+    params = {
+        "fields": "title,authors,venue,year,externalIds,url,abstract",
+        "limit": 1000,
+    }
+    resp = requests.get(url, params=params, timeout=30)
+    resp.raise_for_status()
+    data = resp.json()
+
+    pubs = []
+    for p in data.get("data", []):
+        external_ids = p.get("externalIds") or {}
+        pubs.append(
+            {
+                "title": (p.get("title") or "").strip().rstrip("."),
+                "authors": [a.get("name") for a in p.get("authors", [])],
+                "year": str(p["year"]) if p.get("year") else None,
+                "venue": p.get("venue") or None,
+                "link": p.get("url"),
+                "doi": external_ids.get("DOI"),
+                "abstract": p.get("abstract"),
+                "type": "unknown",
+                "source": "semantic_scholar",
+            }
+        )
+    return pubs
+
+
+def normalize_title(title: str | None) -> str:
+    return "".join(ch.lower() for ch in (title or "") if ch.isalnum())
+
+
+def merge_publications(dblp_pubs: list[dict], s2_pubs: list[dict]) -> list[dict]:
+    """DBLP entries take priority; add S2 entries whose title isn't already present.
+    Also backfill DBLP entries with abstract/doi from S2 when available, matched by title."""
+    s2_by_title = {normalize_title(p["title"]): p for p in s2_pubs if p["title"]}
+
+    merged = []
+    seen_titles = set()
+    for p in dblp_pubs:
+        key = normalize_title(p["title"])
+        s2_match = s2_by_title.get(key)
+        if s2_match:
+            p = dict(p)
+            p["abstract"] = p.get("abstract") or s2_match.get("abstract")
+            p["doi"] = p.get("doi") or s2_match.get("doi")
+        merged.append(p)
+        seen_titles.add(key)
+
+    for p in s2_pubs:
+        key = normalize_title(p["title"])
+        if key and key not in seen_titles:
+            merged.append(p)
+            seen_titles.add(key)
+
+    return merged
+
+
+# Venue strings that indicate a preprint/non-peer-reviewed listing, rather
+# than the actual published venue. Checked as a substring, case-insensitive.
+_PREPRINT_VENUE_MARKERS = ["arxiv", "corr"]
+
+
+def is_preprint_venue(venue: str | None) -> bool:
+    if not venue:
+        return False
+    v = venue.lower()
+    return any(marker in v for marker in _PREPRINT_VENUE_MARKERS)
+
+
+def title_similarity(a: str | None, b: str | None) -> float:
+    """Similarity ratio (0-1) between two normalized titles."""
+    return difflib.SequenceMatcher(None, normalize_title(a), normalize_title(b)).ratio()
+
+
+def dedupe_arxiv_duplicates(
+    pubs: list[dict], threshold: float = ARXIV_TITLE_SIMILARITY_THRESHOLD
+) -> list[dict]:
+    """Collapse cases where the same paper appears twice -- once as an
+    arXiv/preprint listing, once under its real venue -- with a slightly
+    different title (e.g. workshop-shortened title, added subtitle).
+
+    Only merges when one side is a preprint venue and the other is NOT --
+    this is what makes it safe: two genuinely different real papers with
+    similar titles are never touched, since neither would be a preprint
+    venue and the gate below simply won't fire for that pair.
+
+    When a match is found, the real-venue entry is kept (title/venue/link/
+    type come from it), backfilled with abstract/doi from the preprint
+    entry if the real-venue entry is missing them.
+    """
+
+    preprint_pubs = [p for p in pubs if is_preprint_venue(p.get("venue"))]
+    real_pubs = [p for p in pubs if not is_preprint_venue(p.get("venue"))]
+
+    merged_preprint_ids = set()
+    for pp in preprint_pubs:
+        for rp in real_pubs:
+            if title_similarity(pp.get("title"), rp.get("title")) >= threshold:
+                rp["abstract"] = rp.get("abstract") or pp.get("abstract")
+                rp["doi"] = rp.get("doi") or pp.get("doi")
+                merged_preprint_ids.add(id(pp))
+                break
+
+    return real_pubs + [pp for pp in preprint_pubs if id(pp) not in merged_preprint_ids]
+
+
+def filter_by_year(pubs: list[dict], min_year: int | None, max_year: int | None) -> list[dict]:
+    if min_year is None and max_year is None:
+        return pubs
+
+    filtered = []
+    for p in pubs:
+        year = p.get("year")
+        if year is None:
+            continue
+        try:
+            y = int(year)
+        except ValueError:
+            continue
+        if min_year is not None and y < min_year:
+            continue
+        if max_year is not None and y > max_year:
+            continue
+        filtered.append(p)
+    return filtered
+
+
+def to_markdown(pubs: list[dict], header: str = "# Publications") -> str:
+    def sort_key(p):
+        try:
+            return -int(p["year"])
+        except (TypeError, ValueError):
+            return 0
+
+    pubs_sorted = sorted(pubs, key=sort_key)
+
+    lines = [header, ""]
+    current_year = None
+    for p in pubs_sorted:
+        year = p.get("year") or "n.d."
+        if year != current_year:
+            lines.append(f"## {year}")
+            lines.append("")
+            current_year = year
+
+        authors = ", ".join(p.get("authors") or []) or "Unknown authors"
+        venue = p.get("venue")
+        title = p.get("title", "Untitled")
+        link = p.get("link")
+
+        entry = f"**{title}**  \n{authors}"
+        if venue:
+            entry += f"  \n_{venue}_"
+        if link:
+            entry += f"  \n[Link]({link})"
+
+        lines.append(entry)
+        lines.append("")
+
+    return "\n".join(lines)
+
+
+# ------------------------ Existing-site scanning ------------------------
+
+def parse_existing_titles(existing_dir: Path) -> set[str]:
+    """Walk the existing site's publication folders, parse each index.md's
+    YAML front matter, and return a set of normalized titles."""
+    if not os.path.isdir(existing_dir):
+        print(f"WARNING: existing site dir not found: {existing_dir}", file=sys.stderr)
+        return set()
+
+    titles = set()
+    for entry in sorted(os.listdir(existing_dir)):
+        index_path = os.path.join(existing_dir, entry, "index.md")
+        if not os.path.isfile(index_path):
+            continue
+
+        with open(index_path, "r", encoding="utf-8") as f:
+            content = f.read()
+
+        # Front matter is between the first two '---' lines.
+        parts = content.split("---", 2)
+        if len(parts) < 3:
+            print(f"  skip (no front matter): {index_path}", file=sys.stderr)
+            continue
+
+        try:
+            front_matter = yaml.safe_load(parts[1]) or {}
+        except yaml.YAMLError as e:
+            print(f"  skip (YAML parse error in {index_path}): {e}", file=sys.stderr)
+            continue
+
+        title = front_matter.get("title")
+        if title:
+            titles.add(normalize_title(title))
+
+    return titles
+
+
+def find_missing(pubs: list[dict], existing_titles: set[str]) -> list[dict]:
+    return [p for p in pubs if normalize_title(p.get("title")) not in existing_titles]
+
+
+# ------------------------ Hugo Academic index.md ------------------------
+
+def slugify(title: str, max_len: int = 60) -> str:
+    slug = title.lower()
+    slug = re.sub(r"[^a-z0-9\s-]", "", slug)
+    slug = re.sub(r"\s+", "-", slug).strip("-")
+    return slug[:max_len].rstrip("-") or "untitled"
+
+
+def yaml_single_quote(text: str) -> str:
+    return "'" + (text or "").replace("'", "''") + "'"
+
+
+def yaml_block_literal(text: str, indent: int = 4) -> str:
+    if not text:
+        return ""
+    pad = " " * indent
+    wrapped_lines = text.strip().splitlines() or [text.strip()]
+    return "\n".join(pad + line for line in wrapped_lines)
+
+
+def build_index_md(p: dict) -> str:
+    title = p.get("title") or "Untitled"
+    authors = p.get("authors") or []
+    year = p.get("year")
+    venue = p.get("venue") or ""
+    link = p.get("link") or ""
+    doi = p.get("doi") or ""
+    abstract = p.get("abstract") or ""
+
+    subtitle = ", ".join(authors)
+    if venue or year:
+        subtitle += f" - {venue}{(' ' + year) if year else ''}".rstrip()
+
+    date_str = f"{year}-01-01T00:00:00Z" if year else ""
+    pub_type = PUBLICATION_TYPE_MAP.get(p.get("type") or "", DEFAULT_PUBLICATION_TYPE)
+
+    authors_yaml = "\n".join(f"- {a}" for a in authors) if authors else "- "
+
+    abstract_block = (
+        f"abstract: |\n{yaml_block_literal(abstract)}" if abstract else "abstract: "
+    )
+
+    return f"""---
+title: {yaml_single_quote(title)}
+subtitle: {yaml_single_quote(subtitle)}
+# Authors
+# If you created a profile for a user (e.g. the default `admin` user), write the username (folder name) here
+# and it will be replaced with their full name and linked to their profile.
+authors:
+{authors_yaml}
+# Author notes (optional)
+author_notes:
+date: {yaml_single_quote(date_str)}
+doi: {yaml_single_quote(doi)}
+# Schedule page publish date (NOT publication's date).
+publishDate: {yaml_single_quote(date_str)}
+# Publication type.
+# Accepts a single type but formatted as a YAML list (for Hugo requirements).
+# Enter a publication type from the CSL standard.
+publication_types: ['{pub_type}']
+# Publication name and optional abbreviated publication name.
+publication: {yaml_single_quote(venue)}
+publication_short:
+{abstract_block}
+# Summary. An optional shortened abstract.
+summary:
+tags: []
+# Display this page in the Featured widget?
+featured: false
+# Custom links (uncomment lines below)
+# links:
+# - name: Custom Link
+#   url: http://example.org
+url_pdf: {yaml_single_quote(link)}
+url_code: ''
+url_dataset: ''
+url_poster: ''
+url_project: ''
+url_slides: ''
+url_source: ''
+url_video: ''
+# Featured image
+# To use, add an image named `featured.jpg/png` to your page's folder.
+image:
+  caption: ''
+  focal_point: ''
+  preview_only: false
+# Associated Projects (optional).
+#   Associate this publication with one or more of your projects.
+#   Simply enter your project's folder or file name without extension.
+#   E.g. `internal-project` references `content/project/internal-project/index.md`.
+#   Otherwise, set `projects: []`.
+projects: []
+# Slides (optional).
+#   Associate this publication with Markdown slides.
+#   Simply enter your slide deck's filename without extension.
+#   E.g. `slides: "example"` references `content/slides/example/index.md`.
+#   Otherwise, set `slides: ""`.
+slides: ""
+---
+"""
+
+
+def write_paper_folders(pubs: list[dict], papers_dir: Path) -> None:
+    os.makedirs(papers_dir, exist_ok=True)
+    used_slugs = set()
+
+    for p in pubs:
+        base_slug = slugify(p.get("title") or "untitled")
+        slug = base_slug
+        n = 2
+        while slug in used_slugs:
+            slug = f"{base_slug}-{n}"
+            n += 1
+        used_slugs.add(slug)
+
+        folder = os.path.join(papers_dir, slug)
+        os.makedirs(folder, exist_ok=True)
+        with open(os.path.join(folder, "index.md"), "w", encoding="utf-8") as f:
+            f.write(build_index_md(p))
+
+    print(f"Wrote {len(pubs)} paper folders under {papers_dir}", file=sys.stderr)
+
+
+def main():
+    min_year, max_year = MIN_YEAR, MAX_YEAR
+    if YEAR is not None:
+        min_year = max_year = YEAR
+
+    print(f"Fetching DBLP publications from {DBLP_URL} ...", file=sys.stderr)
+    dblp_pubs = fetch_dblp(DBLP_URL)
+    print(f"  -> {len(dblp_pubs)} entries from DBLP", file=sys.stderr)
+
+    s2_pubs = []
+    if SEMANTIC_SCHOLAR_ID:
+        print(f"Fetching Semantic Scholar publications for author {SEMANTIC_SCHOLAR_ID} ...", file=sys.stderr)
+        s2_pubs = fetch_semantic_scholar(SEMANTIC_SCHOLAR_ID)
+        print(f"  -> {len(s2_pubs)} entries from Semantic Scholar", file=sys.stderr)
+
+    merged = merge_publications(dblp_pubs, s2_pubs)
+    print(f"Merged total: {len(merged)} unique publications", file=sys.stderr)
+
+    before_dedup = len(merged)
+    merged = dedupe_arxiv_duplicates(merged)
+    if len(merged) < before_dedup:
+        print(
+            f"Collapsed {before_dedup - len(merged)} arXiv/preprint duplicate(s) "
+            f"into their real-venue counterpart",
+            file=sys.stderr,
+        )
+
+    if min_year is not None or max_year is not None:
+        merged = filter_by_year(merged, min_year, max_year)
+        print(f"After year filter: {len(merged)} publications", file=sys.stderr)
+
+    # 1. Diff against the existing site
+    print(f"Scanning existing site publications in {EXISTING_SITE_DIR} ...", file=sys.stderr)
+    existing_titles = parse_existing_titles(EXISTING_SITE_DIR)
+    print(f"  -> {len(existing_titles)} existing papers found on site", file=sys.stderr)
+
+    missing = find_missing(merged, existing_titles)
+    print(f"Missing from site: {len(missing)} papers", file=sys.stderr)
+
+    missing_md = to_markdown(missing, header="# Papers Missing From Website")
+    with open(MISSING_REPORT_PATH, "w", encoding="utf-8") as f:
+        f.write(missing_md)
+    print(f"Wrote missing-papers report to {MISSING_REPORT_PATH}", file=sys.stderr)
+
+    # 2. Optionally generate ready-to-use folders for just the missing papers
+    if GENERATE_MISSING_FOLDERS and missing:
+        write_paper_folders(missing, MISSING_PAPERS_DIR)
+
+
+if __name__ == "__main__":
+    main()

--- a/publication-sync/google_scholar_citations.py
+++ b/publication-sync/google_scholar_citations.py
@@ -1,0 +1,160 @@
+#!/usr/bin/env python3
+"""
+Google Scholar author-profile scraper -- citation counts only.
+
+IMPORTANT CONTEXT (read before running):
+  - This is NOT part of the main publication-sync pipeline (scholar_scraper.py).
+    That script (DBLP + Semantic Scholar) is what generates the actual
+    website content and should stay the source of truth for titles,
+    authors, venues, links, and abstracts.
+  - This script exists ONLY to pull the one thing Scholar has that
+    DBLP/S2 don't: citation counts and h-index/i10-index. Treat its
+    output as supplementary data (e.g. "N citations" badges), not as
+    a replacement pipeline.
+  - Google Scholar has no public API, explicitly disallows automated
+    scraping in its Terms of Service, and aggressively rate-limits or
+    CAPTCHAs repeated automated access. Run this occasionally / by hand
+    when you actually need updated citation numbers -- not on a schedule,
+    not in CI, not repeatedly in a short window. If you get blocked,
+    that's Scholar's anti-bot system working as intended; back off and
+    try again later rather than retrying immediately.
+  - Requires: pip install undetected-chromedriver selenium
+
+Usage:
+    python scholar_citations.py
+"""
+
+import json
+import re
+import sys
+import time
+from config import cfg
+
+import undetected_chromedriver as uc
+from selenium.webdriver.common.by import By
+
+# ----------------------------- CONFIG -----------------------------
+PROFILE_URL = cfg.google_scholar_profile_url #"https://scholar.google.com/citations?user=pKbJC10AAAAJ&hl=en"
+OUTPUT_JSON = cfg.scholar_output_json #"/Users/swarnadeep/Riju/Code/academic/XplaiNLP/scrapper/data/output/scholar_citations.json"
+HEADLESS = cfg.headless
+# Be polite / avoid tripping rate limits: small delay between "Show more" clicks
+CLICK_DELAY_SECONDS = cfg.click_delay_seconds #2
+MAX_SHOW_MORE_CLICKS = cfg.max_show_more_clicks  # safety cap
+# --------------------------------------------------------------------
+
+
+def get_browser():
+    options = uc.ChromeOptions()
+    if HEADLESS:
+        options.add_argument("--headless=new")
+    return uc.Chrome(options=options,version_main=150)
+
+
+def expand_all_publications(browser) -> None:
+    """Click 'Show more' repeatedly until all publications are loaded
+    or the button becomes disabled/disappears."""
+    for _ in range(MAX_SHOW_MORE_CLICKS):
+        try:
+            button = browser.find_element(By.ID, "gsc_bpf_more")
+        except Exception:
+            break  # button not found, nothing more to expand
+
+        if not button.is_enabled():
+            break
+
+        button.click()
+        time.sleep(CLICK_DELAY_SECONDS)
+
+
+def parse_overall_stats(browser) -> dict:
+    """Parse the citation/h-index/i10-index summary table (gsc_rsb_st)."""
+    stats = {}
+    try:
+        cells = browser.find_elements(By.CSS_SELECTOR, "table#gsc_rsb_st td.gsc_rsb_std")
+        values = [c.text.strip() for c in cells]
+        # Order on the page: Citations(All, Since), h-index(All, Since), i10-index(All, Since)
+        labels = [
+            "citations_all", "citations_since",
+            "h_index_all", "h_index_since",
+            "i10_index_all", "i10_index_since",
+        ]
+        for label, value in zip(labels, values):
+            stats[label] = int(value) if value.isdigit() else value
+    except Exception as e:
+        print(f"WARNING: could not parse overall stats: {e}", file=sys.stderr)
+    return stats
+
+
+def normalize_title(title: str) -> str:
+    return "".join(ch.lower() for ch in (title or "") if ch.isalnum())
+
+
+def parse_publications(browser) -> list[dict]:
+    pubs = []
+    rows = browser.find_elements(By.CSS_SELECTOR, "table#gsc_a_t tr.gsc_a_tr")
+
+    for row in rows:
+        try:
+            title_el = row.find_element(By.CSS_SELECTOR, "td.gsc_a_t a.gsc_a_at")
+            title = title_el.text.strip()
+
+            gray_divs = row.find_elements(By.CSS_SELECTOR, "td.gsc_a_t div.gs_gray")
+            authors = gray_divs[0].text.strip() if len(gray_divs) > 0 else ""
+            venue = gray_divs[1].text.strip() if len(gray_divs) > 1 else ""
+
+            year_el = row.find_elements(By.CSS_SELECTOR, "td.gsc_a_y span")
+            year = year_el[0].text.strip() if year_el else ""
+
+            citation_el = row.find_elements(By.CSS_SELECTOR, "td.gsc_a_c a.gsc_a_ac")
+            citation_text = citation_el[0].text.strip() if citation_el else ""
+            citations = int(citation_text) if citation_text.isdigit() else 0
+
+            pubs.append(
+                {
+                    "title": title,
+                    "authors_raw": authors,
+                    "venue_raw": venue,
+                    "year": year,
+                    "citations": citations,
+                    "normalized_title": normalize_title(title),
+                }
+            )
+        except Exception as e:
+            print(f"WARNING: skipped a row due to parse error: {e}", file=sys.stderr)
+            continue
+
+    return pubs
+
+
+def main():
+    print(f"Launching browser (headless={HEADLESS}) ...", file=sys.stderr)
+    browser = get_browser()
+
+    try:
+        print(f"Fetching {PROFILE_URL} ...", file=sys.stderr)
+        browser.get(PROFILE_URL)
+        time.sleep(3)  # let the page settle before interacting
+
+        print("Expanding full publication list ...", file=sys.stderr)
+        expand_all_publications(browser)
+
+        print("Parsing overall stats ...", file=sys.stderr)
+        stats = parse_overall_stats(browser)
+        print(f"  -> {stats}", file=sys.stderr)
+
+        print("Parsing publications table ...", file=sys.stderr)
+        pubs = parse_publications(browser)
+        print(f"  -> {len(pubs)} publications found", file=sys.stderr)
+
+    finally:
+        browser.quit()
+
+    output = {"profile_url": PROFILE_URL, "overall_stats": stats, "publications": pubs}
+    with open(OUTPUT_JSON, "w", encoding="utf-8") as f:
+        json.dump(output, f, indent=2, ensure_ascii=False)
+
+    print(f"Wrote {OUTPUT_JSON}", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    main()

--- a/publication-sync/sanity_check.py
+++ b/publication-sync/sanity_check.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+"""
+Pre-upload sanity check for missing_papers/.
+
+Run this after generating missing_papers/ (via dblp_semantic_scraper.py
+and/or cross_check_scholar.py) and BEFORE copying anything into
+content/publication/. Checks:
+
+  1. No duplicate titles within missing_papers/ itself.
+  2. None of the missing_papers/ titles already exist on the live site
+     (a fresh re-check, independent of whatever the generating scripts
+     computed -- catches drift if the site changed since then).
+  3. No empty/placeholder titles.
+
+Exits with a clear PASS/FAIL summary. This does not modify anything --
+read-only checks against the two local folders.
+
+Usage:
+    python sanity_check.py
+"""
+
+import os
+import sys
+from collections import defaultdict
+from config import cfg
+from pathlib import Path
+
+import dblp_semantic_scraper as sync  # reuse parse_existing_titles, normalize_title
+
+# ----------------------------- CONFIG -----------------------------
+MISSING_PAPERS_DIR = cfg.missing_papers_dir #"/Users/swarnadeep/Riju/Code/academic/XplaiNLP/scrapper/data/output/missing_papers"
+EXISTING_SITE_DIR = cfg.existing_site_dir #"/Users/swarnadeep/Riju/Code/academic/XplaiNLP/xplainlp.github.io/content/publication"
+# --------------------------------------------------------------------
+
+
+def load_missing_titles(missing_dir: Path) -> list[tuple[str, str]]:
+    """Returns list of (folder_name, title) for every folder with an index.md."""
+    if not os.path.isdir(missing_dir):
+        print(f"ERROR: missing_papers dir not found: {missing_dir}", file=sys.stderr)
+        sys.exit(1)
+
+    entries = []
+    for entry in sorted(os.listdir(missing_dir)):
+        index_path = os.path.join(missing_dir, entry, "index.md")
+        if not os.path.isfile(index_path):
+            continue
+        with open(index_path, "r", encoding="utf-8") as f:
+            content = f.read()
+        parts = content.split("---", 2)
+        if len(parts) < 3:
+            entries.append((entry, None))
+            continue
+        import yaml
+        try:
+            front_matter = yaml.safe_load(parts[1]) or {}
+        except yaml.YAMLError:
+            entries.append((entry, None))
+            continue
+        title = front_matter.get("title")
+        entries.append((entry, title))
+    return entries
+
+
+def main():
+    print(f"Loading missing_papers from {MISSING_PAPERS_DIR} ...", file=sys.stderr)
+    entries = load_missing_titles(MISSING_PAPERS_DIR)
+    print(f"  -> {len(entries)} folders found\n", file=sys.stderr)
+
+    problems = []
+
+    # Check 1: empty/placeholder titles
+    empty = [folder for folder, title in entries if not title or title.strip() == "" or title == "Untitled"]
+    if empty:
+        problems.append(f"{len(empty)} folder(s) with empty/placeholder title:")
+        for f in empty:
+            problems.append(f"  - {f}")
+
+    # Check 2: duplicate titles WITHIN missing_papers/
+    by_normalized = defaultdict(list)
+    for folder, title in entries:
+        if title:
+            by_normalized[sync.normalize_title(title)].append((folder, title))
+
+    duplicates = {k: v for k, v in by_normalized.items() if len(v) > 1}
+    if duplicates:
+        problems.append(f"\n{len(duplicates)} duplicate title group(s) WITHIN missing_papers/:")
+        for norm_title, group in duplicates.items():
+            problems.append(f"  Title match: {group[0][1]!r}")
+            for folder, title in group:
+                problems.append(f"    - {folder}/  (title: {title!r})")
+
+    # Check 3: fresh re-check against the live site
+    print(f"Re-scanning live site at {EXISTING_SITE_DIR} ...", file=sys.stderr)
+    existing_titles = sync.parse_existing_titles(EXISTING_SITE_DIR)
+    print(f"  -> {len(existing_titles)} titles currently on site\n", file=sys.stderr)
+
+    already_on_site = [
+        (folder, title) for folder, title in entries
+        if title and sync.normalize_title(title) in existing_titles
+    ]
+    if already_on_site:
+        problems.append(f"\n{len(already_on_site)} folder(s) ALREADY on the live site (stale, should be removed):")
+        for folder, title in already_on_site:
+            problems.append(f"  - {folder}/  (title: {title!r})")
+
+    # Summary
+    print("=" * 60)
+    if not problems:
+        print(f"PASS -- {len(entries)} papers checked, no duplicates, no titles already on site.")
+        print("Safe to review individually and copy into content/publication/.")
+    else:
+        print(f"FAIL -- issues found in {len(entries)} papers checked:\n")
+        print("\n".join(problems))
+        print("\nFix these before uploading. Duplicates: keep the better-sourced")
+        print("folder (has a real link/DOI) and delete the other. Already-on-site")
+        print("entries: just delete that folder, it's stale output from an earlier run.")
+    print("=" * 60)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

This PR adds a publication synchronization tool to automate updating the XplaiNLP website's publication list.

### Features

- Retrieve publication metadata from DBLP.
- Cross-check publication information.
- Fetch citation counts from Google Scholar.
- Perform sanity checks before publication.
- Generate Hugo-compatible publication pages.

### Notes

- The tool is intended to be run **locally** from a user's machine.
- It is **not** a hosted or continuously running service.
- The current implementation uses **Vera Schmitt's DBLP and Google Scholar profiles as the anchor** for discovering and synchronizing publications.
- All configuration is centralized in `config.py`.
- Local paths can be updated in the configuration file to match the user's environment.